### PR TITLE
added "escape" into post title field because something broke in beta.…

### DIFF
--- a/_includes/post.json
+++ b/_includes/post.json
@@ -1,6 +1,6 @@
 {
     "id": "{{- index -}}",
     "url": "{{- post.permalink | relative_url -}}{{- post.file_url | relative_url -}}",
-    "title": "{{- post.title -}}",
+    "title": "{{- post.title | escape -}}",
     "content": "{{- post.content | markdownify | strip_html | remove: '<br>' | remove: '\"' | strip_newlines | escape -}}",
 }

--- a/resource_room/forms-and-templates/_posts/2012-07-20-service-increment-for-2011-and-salary-range-in-ca-for-2011-to-2013.md
+++ b/resource_room/forms-and-templates/_posts/2012-07-20-service-increment-for-2011-and-salary-range-in-ca-for-2011-to-2013.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "Service Increment for 2011 and Salary Range in CA for 2011-2013"
+title:  Service Increment for 2011 and Salary Range in CA for 2011-2013"
 date:   2012-07-20
 excerpt: "The Singapore Manual & Mercantile Workers' Union v. China Airlines Limited: The Court rhas been adjourned to a date to be fixed."
 permalink: "/media/corporate-publications/service-increment"


### PR DESCRIPTION
…tech.gov.sg due to unescaped quotation marks