### PR TITLE
Fixed og-description for homepage

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,8 @@
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <meta property="og:title" content="{{page.title}}">
-    <meta property="og:description" content="{{page.content | truncatewords: 20 | strip_html}}">
+    <!-- If page contains a description in the YML header of the markdown file, use the page description. Otherwise, take an excerpt of its markdown content -->
+    <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{page.content | truncatewords: 20 | strip_html}}{% endif %}"> 
     {% assign homepage = site.data.homepage %}
     <meta property="og:image" content="{% if page.image %}{{page.image | absolute_url}}{% else %}{{homepage.agency-logo | absolute_url}}{% endif %}">
     <meta property="og:url" content="{{page.permalink | absolute_url}}">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,9 +3,9 @@
     <meta name="viewport"
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta property="og:title" content="{{page.title}}">
+    <meta property="og:title" content="{{page.title | markdownify | strip_html}}">
     <!-- If page contains a description in the YML header of the markdown file, use the page description. Otherwise, take an excerpt of its markdown content -->
-    <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{page.content | truncatewords: 20 | strip_html}}{% endif %}"> 
+    <meta property="og:description" content="{% if page.description %}{{ page.description | markdownify | strip_html }}{% else %}{{page.content | truncatewords: 20 | markdownify | strip_html }}{% endif %}"> 
     {% assign homepage = site.data.homepage %}
     <meta property="og:image" content="{% if page.image %}{{page.image | absolute_url}}{% else %}{{homepage.agency-logo | absolute_url}}{% endif %}">
     <meta property="og:url" content="{{page.permalink | absolute_url}}">

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 layout: homepage
 title: Isomer Pages Templates
-description: test
+description: test **test**
 permalink: /
 ---
 <!-- Type your notification here - the notification bar will not appear if this is empty. For other changes, refer to _data/homepage.yml to edit the homepage -->

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 layout: homepage
 title: Isomer Pages Templates
+description: test
 permalink: /
 ---
 <!-- Type your notification here - the notification bar will not appear if this is empty. For other changes, refer to _data/homepage.yml to edit the homepage -->


### PR DESCRIPTION
This fixes the following bugs:
- The og-description tag currently takes an excerpt of the markdown content from the markdown file

**Bug 1**
- this creates a bug when the homepage's index.md file has banner text - because the meta tag og-description will display that banner text, e.g. in the case below
```
<!-- Type your notification here - the notification bar will not appear if this is empty. For other changes, refer to _data/homepage.yml to edit the homepage -->
###### This website is in beta - your valuable [feedback]({{site.feedback_form_url}}){:target="_blank"} will help us in improving it.
```

**Bug 2**
- The markdown syntax is displayed in the meta tag for og-description (and also og-title)

Fix:
- Created the option `page.description` to allow users to override and provide their own page description instead of automatically taking an excerpt from the existing content
- Added a markdownify | strip_html liquid tag to remove all markdown syntax from og-description and og-title before displaying them