### PR TITLE
converts remove function into ES5 syntax to fix IE11 bugs

### DIFF
--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -100,8 +100,10 @@ function hideAllPostsAndPagination() {
   document.querySelector(".pagination").style.display = "none";
 }
 
-function remove(array, elements) {
-  return array.filter(e => !elements.includes(e.id));
+function remove(array, elements){
+  return array.filter(function(e) { 
+    return (!elements.includes(e.id));
+  })
 }
 
 // Populate the pagination elements


### PR DESCRIPTION
Todo: convert back to ES6 and use babel