### PR TITLE
changes code to deal with empty query string in data.gov.sg search

### DIFF
--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -16,18 +16,18 @@ let datagovsgTotal; // The total number of rows of data in the datagovsg API
 
 let currentPageIndex = 0;
 
-var searchTerm = getQueryVariable('query');
+let searchTerm = getQueryVariable('query');
 if (! searchTerm) {
   searchTerm = '';
 }
 databaseSearch(searchTerm, startIndex);
 
 function getQueryVariable(variable) {
-  var query = window.location.search.substring(1);
-  var vars = query.split('&');
+  let query = window.location.search.substring(1);
+  let vars = query.split('&');
 
-  for (var i = 0; i < vars.length; i++) {
-    var pair = vars[i].split('=');
+  for (let i = 0; i < vars.length; i++) {
+    let pair = vars[i].split('=');
 
     if (pair[0] === variable) {
       const dirtyString = decodeURIComponent(pair[1].replace(/\+/g, '%20'));
@@ -37,13 +37,21 @@ function getQueryVariable(variable) {
 }
 
 function databaseSearch(searchTerm, index){
-  var data = {
-    resource_id: resourceId, // the resource id
-    q: searchTerm,
-    offset: datagovsgOffset
-  };
+  if (searchTerm !== ''){
+    var data = {
+      resource_id: resourceId, // the resource id
+      q: searchTerm,
+      offset: datagovsgOffset
+    }
+  }
+  else {
+    var data = {
+      resource_id: resourceId, // the resource id
+      offset: datagovsgOffset
+    }    
+  }
 
-  var request = $.ajax({
+  let request = $.ajax({
     url: 'https://data.gov.sg/api/action/datastore_search',
     data: data,
     dataType: 'json',
@@ -68,17 +76,17 @@ function displayTable(chunk, fields) {
     return;
   }
 
-  var resultString = "<div><table class=\"table-h\"><tr>";
+  let resultString = "<div><table class=\"table-h\"><tr>";
   for (fieldIndex in fields) {
-    var fieldId = fields[fieldIndex].id;
+    let fieldId = fields[fieldIndex].id;
     resultString += '<td><h6 class=\"margin--none\"><b>' + fieldId.replace(/_/g, ' ').toUpperCase() + '</b></h6></td>';
   }
   resultString += '</tr>'
 
-  for (var chunkIndex = 0; chunkIndex < chunk.length; chunkIndex++) {
+  for (let chunkIndex = 0; chunkIndex < chunk.length; chunkIndex++) {
     resultString += '<tr>'
     for (fieldIndex in fields) {
-      var fieldId = fields[fieldIndex].id;
+      let fieldId = fields[fieldIndex].id;
       resultString += '<td><h6 class=\"margin--none\">' + chunk[chunkIndex][fieldId] + '</h6></td>';
     }
     resultString += '</tr>'
@@ -92,7 +100,7 @@ function displayTable(chunk, fields) {
 
 function hideAllPostsAndPagination() {
 
-  var paginationElement = document.getElementById("paginator-pages");
+  let paginationElement = document.getElementById("paginator-pages");
   while (paginationElement.firstChild) {
       paginationElement.removeChild(paginationElement.firstChild);
   }
@@ -107,7 +115,7 @@ function remove(array, elements) {
 // Populate the pagination elements
 function displayPagination(index) {
   document.querySelector(".pagination").style.display = "flex";
-  var pagination = document.getElementById('paginator-pages');
+  let pagination = document.getElementById('paginator-pages');
 
   for (let i = 0; i < pageResults.length; i++) {
     let ele = document.createElement("span");

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -37,18 +37,13 @@ function getQueryVariable(variable) {
 }
 
 function databaseSearch(searchTerm, index){
-  if (searchTerm !== ''){
-    var data = {
-      resource_id: resourceId, // the resource id
-      q: searchTerm,
-      offset: datagovsgOffset
-    }
+  let data = {
+    resource_id: resourceId, // the resource id
+    offset: datagovsgOffset
   }
-  else {
-    var data = {
-      resource_id: resourceId, // the resource id
-      offset: datagovsgOffset
-    }    
+  
+  if (searchTerm !== '') {
+    data.q = searchTerm
   }
 
   let request = $.ajax({


### PR DESCRIPTION
Currently, data.gov.sg's API search has a minor bug in which an empty query variable in API will lead to no results being returned.

<img width="1552" alt="screen shot 2019-01-17 at 6 44 38 pm" src="https://user-images.githubusercontent.com/19917616/51313201-f97aea00-1a87-11e9-99ca-6eea64c97ac1.png">

### **Problem**

Specifically, this breaks:
`https://data.gov.sg/api/action/datastore_search?resource_id=375d9a9c-9039-4ed5-830a-dcec60f36b88&q=&offset=0`

But searches with non-empty query variables or searches without the `q` variable still work:
`https://data.gov.sg/api/action/datastore_search?resource_id=375d9a9c-9039-4ed5-830a-dcec60f36b88&q=test&offset=0`

`https://data.gov.sg/api/action/datastore_search?resource_id=375d9a9c-9039-4ed5-830a-dcec60f36b88&offset=0`

### **Fix**
I wrote a [simple check here](https://github.com/isomerpages/isomerpages-template/blob/staging/assets/js/datagovsg-search.js#L40-L47) to see if `searchTerm` is empty before generating the `data` object. The `data` object is subsequently used by `ajax` to make the API call.

If `searchTerm` is empty, the `data` object looks like:
```
    var data = {
      resource_id: resourceId, // the resource id
      offset: datagovsgOffset
    } 
```

If `searchTerm` is a string, the `data` object looks like:
```
    var data = {
      resource_id: resourceId, // the resource id
      q: searchTerm,
      offset: datagovsgOffset
    }
```

### **Misc**
Converted all occurrences of `var` to `let` for better style... I need to lint this entire project soon.