### PR TITLE
fixes datagovsg search bugs

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -13,6 +13,11 @@ var currentPageIndex = 0;
 var runSearch = function runSearch(json_data, posts_data) {
   postsData = posts_data;
   var searchTerm = getQueryVariable('query');
+  
+  if (!searchTerm || searchTerm === '+') {
+    searchTerm = ' ';
+  }
+  
   if (searchTerm) {
 
     // Load the pre-built lunr index

--- a/pages/data-gov-sg-search.md
+++ b/pages/data-gov-sg-search.md
@@ -3,5 +3,5 @@ layout: datagovsg-search
 title: Data.gov.sg Search
 permalink: /data-gov-sg/
 breadcrumb: Data.gov.sg Search
-datagovsg-id: 18a5ef70-dc13-4249-a8d1-b34823fec471
+datagovsg-id: 375d9a9c-9039-4ed5-830a-dcec60f36b88
 ---

--- a/pages/database-search.md
+++ b/pages/database-search.md
@@ -3,5 +3,5 @@ layout: datagovsg-search
 title: Database Search
 permalink: /database-search/
 breadcrumb: Database Search
-datagovsg-id: a41ce851-728e-4d65-8dc5-e0515a01ff31
+datagovsg-id: 375d9a9c-9039-4ed5-830a-dcec60f36b88
 ---


### PR DESCRIPTION
This PR fixes the following datagovsg-search bugs:
1. Currently, if the number of search results < 100 and hence the number of pages < 10, the entire pagination is not displayed - corrected the logic error in the code.
2. Currently, if the AJAX call to datagovsg fails, the page does not handle the error well - added error handling.
3. Fixes the broken search if there is an attempted <script> tag injection into the search parameters.