### PR TITLE
Exclude Travis CI scripts from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,7 +33,7 @@ plugins:
   # - jekyll-paginate-v2
   # - sanitize
 safe: false
-
+exclude: [travis-script.js, .travis.yml, README.md, package.json, package-lock.json, test_suite]
 
 # Breadcrumbs
 breadcrumbs:


### PR DESCRIPTION
As discussed today, I have added an exclude list to _config.yml to prevent our Travis CI and other scripts and miscellaneous files from being placed onto the production server.

This commit will also exclude my test suite as it stands right now.

Files such as .gitignore and .travis.yml are automatically excluded so there is no need to add it into the exclude list here.