### PR TITLE
Enhance opengraph image support

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
     <meta property="og:description" content="{% if page.description %}{{ page.description | markdownify | strip_html }}{% else %}{{page.content | truncatewords: 20 | markdownify | strip_html }}{% endif %}"> 
     <meta name="Description" CONTENT="{% if page.description %}{{ page.description | markdownify | strip_html }}{% else %}{{page.content | truncatewords: 20 | markdownify | strip_html }}{% endif %}">
     {% assign homepage = site.data.homepage %}
-    <meta property="og:image" content="{% if page.image %}{{page.image | absolute_url}}{% else %}{{homepage.agency-logo | absolute_url}}{% endif %}">
+    <meta property="og:image" content="{% if page.image %}{{page.image | absolute_url}}{% elsif homepage.shareicon %}{{homepage.shareicon | absolute_url}}{% else %}{{homepage.agency-logo | absolute_url}}{% endif %}">
     <meta property="og:url" content="{{page.permalink | absolute_url}}">
     <link rel="canonical" href="{{ page.url | absolute_url}}" />
     


### PR DESCRIPTION
Now a website can specify `shareicon` under `homepage.yml` if they have a Open Graph square image they wish to display on WhatsApp/FB/etc. It falls back to the agency logo if left unspecified