### PR TITLE
Fix bug where raw markdown appears in description

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <meta property="og:title" content="{{page.title | markdownify | strip_html}}">
     <!-- If page contains a description in the YML header of the markdown file, use the page description. Otherwise, take an excerpt of its markdown content -->
-    <meta property="og:description" content="{% if page.description %}{{ page.description | markdownify | strip_html }}{% else %}{{page.content | truncatewords: 20 | markdownify | strip_html }}{% endif %}"> 
-    <meta name="Description" CONTENT="{% if page.description %}{{ page.description | markdownify | strip_html }}{% else %}{{page.content | truncatewords: 20 | markdownify | strip_html }}{% endif %}">
+    <meta property="og:description" content="{% if page.description %}{{ page.description | markdownify | strip_html }}{% else %}{{page.content | markdownify | strip_html | truncatewords: 20}}{% endif %}"> 
+    <meta name="Description" CONTENT="{% if page.description %}{{ page.description | markdownify | strip_html }}{% else %}{{page.content | markdownify | strip_html | truncatewords: 20}}{% endif %}">
     {% assign homepage = site.data.homepage %}
     <meta property="og:image" content="{% if page.image %}{{page.image | absolute_url}}{% elsif homepage.shareicon %}{{homepage.shareicon | absolute_url}}{% else %}{{homepage.agency-logo | absolute_url}}{% endif %}">
     <meta property="og:url" content="{{page.permalink | absolute_url}}">


### PR DESCRIPTION
There was a bug where the description fields under `<meta>` will read something like `Text title ### Markdown Header` because `truncatewords: 20` will truncate halfway through a markdown tag. This fixes the issue by converting the whole page into plain English without any Markdown/HTML, then truncating the text last.