### PR TITLE
Fix filetype icon overlap issue and left nav arrow line break issue

### DIFF
--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -3903,6 +3903,9 @@ a[href$=".pdf"][target=_blank]:after {
     font-size: 1.5rem; }
 .bp-menu-list {
   line-height: 1.25; }
+.has-side-nav{
+  box-sizing: unset;
+}
   .bp-menu-list a {
     font-size: 1.0625rem;
     color: #323232;

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -3576,11 +3576,8 @@ a[href$=".pdf"] {
     font-family: "sgds-icons";
     content: "";
     position: absolute;
-    top: 0;
-    left: -2.25rem;
+    left: -2rem;
     height: 100%;
-    display: flex;
-    flex-direction: row;
     align-items: center;
     justify-content: center; }
     a[href$=".pdf"]:before:hover {


### PR DESCRIPTION
Issue occurs on Chrome/Safari/other WebKit browsers when link to file occupies more than 1 line, as seen below:

![Screenshot of page on iOS Safari with the PDF icon embedded in the link text](https://user-images.githubusercontent.com/1127543/54100077-95293680-43f7-11e9-8637-f2943e7e2c3e.jpg)
