### PR TITLE
Removes render blocking carousel load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 _site
 Gemfile.lock
 *.DS_Store
+.DS_Store
+node_modules
+.jekyll-metadata

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -3903,6 +3903,9 @@ a[href$=".pdf"][target=_blank]:after {
     font-size: 1.5rem; }
 .bp-menu-list {
   line-height: 1.25; }
+.has-side-nav{
+  box-sizing: unset;
+}
   .bp-menu-list a {
     font-size: 1.0625rem;
     color: #323232;

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -380,4 +380,7 @@ $(document).ready(function(){
         searchBar_input.focus().val('');
         masthead_container.toggleClass('is-opened');
     });
+
+    // Wrap all tables in a <div> with the horizontal-scroll class so that the table will not be cut off on mobile
+    $('table').wrap('<div class="horizontal-scroll"></div>');
 });

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-XSS-Protection = "1; mode=block"
+    Referrer-Policy = "no-referrer"
+    X-Content-Type-Options = "nosniff"


### PR DESCRIPTION
Redoing the carousel optimization:
- load carousel js and css only when needed, and if it is the homepage
- move the carousel js and css to load after the HTML loads

Previous problem with carousel optimization:
- moved carousel js and css to after jquery loads; however, owl carousel requires jquery. this broke the carousel.