### PR TITLE
Remove is_government check for copyright notice

### DIFF
--- a/_includes/bp-footer.html
+++ b/_includes/bp-footer.html
@@ -176,14 +176,10 @@
             </div>
             <div class="col is-one-third has-text-right-desktop has-text-right-tablet has-text-left-mobile">
                 <p class="is-hidden-touch is-hidden-desktop-only"> © {{ site.time | date: "%Y" }} 
-                {% unless site.is_government == false %}
                   {{site.title}}
-                {% endunless %}
                 <p class="is-hidden-touch is-hidden-desktop-only last-updated">
                 Last Updated {{ site.time | date_to_string }}</p>
-                {% unless site.is_government == false %}
                   <p class="is-hidden-widescreen">© {{ site.time | date: "%Y" }} {{site.title}}</p>
-                {% endunless %}
                 <p class="is-hidden-widescreen last-updated">Last Updated {{ site.time | date_to_string }}</p>
             </div>
 


### PR DESCRIPTION
The `is_government` check is no longer required since we are no longer copyrighting Isomer websites under "Singapore Government", using the site title as configured in `_config.yml` instead

This addresses bug #97 