### PR TITLE
Hide feedback form links if feedback_url is not specified

### DIFF
--- a/_includes/bp-footer.html
+++ b/_includes/bp-footer.html
@@ -123,9 +123,11 @@
                  <p><a href="https://www.reach.gov.sg/" target="_blank" rel="noreferrer" title="Link to reach.gov.sg">REACH</a></p>
                </li>
                {% endif %}
+               {% if site.feedback_form_url %}
                <li class="is-inline-block-desktop-only">
                   <p><a href="{{site.feedback_form_url}}" target="_blank" rel="noreferrer">Feedback</a></p>
                </li>
+               {% endif %}
                {% assign homepage = site.data.homepage %}
                {% unless homepage.ask-jamie %}
                <li class="is-inline-block-desktop-only">

--- a/_layouts/contact-us.html
+++ b/_layouts/contact-us.html
@@ -105,6 +105,7 @@ layout: default
                     {% endfor %}
 
                 </div>
+                {% if site.feedback_form_url %}
                 <div class="row is-multiline margin--bottom--lg">
                     <div class="col is-12 padding--bottom--none">
                         <h5 class="has-text-secondary has-text-weight-semibold">Send us your feedback</h5>
@@ -116,6 +117,7 @@ layout: default
                         </p>
                     </div>
                 </div>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -312,9 +312,7 @@ code > span,
 pre > span {
   -moz-osx-font-smoothing: auto;
   -webkit-font-smoothing: auto;
-  font-family: monospace }
-
-
+  font-family: monospace; }
 
 body {
   color: #484848;

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -307,10 +307,14 @@ textarea {
   font-family: "Lato", BlinkMacSystemFont, -apple-system, "Segoe UI", "Helvetica Neue", "Helvetica", "Arial", sans-serif; }
 
 code,
-pre {
+pre,
+code > span,
+pre > span {
   -moz-osx-font-smoothing: auto;
   -webkit-font-smoothing: auto;
-  font-family: monospace !important; }
+  font-family: monospace }
+
+
 
 body {
   color: #484848;


### PR DESCRIPTION
The second commit sets a monospace font for code elements with syntax highlighting