### PR TITLE
Add page recommendation feature

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,6 +73,9 @@ faq_url_external: true
 custom_css_path: "/do-not-touch/theme-colors/custom.css"
 custom_print_css_path: "/assets/css/print.css"
 
+# Isomer recommender system - only works for simple-page, leftnav-page, and post
+recommender: true
+
 # ############################################################
 # # Site configuration for the Jekyll 3 Pagination Gem
 # # The values here represent the defaults if nothing is set

--- a/_includes/main-scripts.html
+++ b/_includes/main-scripts.html
@@ -62,6 +62,9 @@
 <script src="https://printjs-4de6.kxcdn.com/print.min.js" integrity="sha384-htjK5WN4qR+MbNZFQSenyRKW+3CjwUTTXs3vGU3DcZncFSI7AzNZUIOgyZjdetLU" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/floating-buttons.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/left-nav-interaction.js" | relative_url -}}" crossorigin="anonymous"></script>
+  {%- if site.recommender == true -%}
+  <script src="{{- "/assets/js/recommender.js" | relative_url -}}" crossorigin="anonymous"></script>
+  {%- endif -%}
 {%- endif -%}
 
 {%- include chatbot-scripts.html -%}

--- a/_includes/main-scripts.html
+++ b/_includes/main-scripts.html
@@ -59,7 +59,7 @@
 {%- endif -%}
 
 {%- if page.layout == 'post' or page.layout == 'simple-page' or page.layout == 'leftnav-page-content' or page.layout == 'our-team' or page.layout == 'our-journey' -%}
-<script src="https://printjs-4de6.kxcdn.com/print.min.js" integrity="sha384-htjK5WN4qR+MbNZFQSenyRKW+3CjwUTTXs3vGU3DcZncFSI7AzNZUIOgyZjdetLU" crossorigin="anonymous"></script>
+<script src="https://printjs-4de6.kxcdn.com/print.min.js" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/floating-buttons.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/left-nav-interaction.js" | relative_url -}}" crossorigin="anonymous"></script>
   {%- if site.recommender == true -%}

--- a/_includes/recommender.html
+++ b/_includes/recommender.html
@@ -1,0 +1,8 @@
+<div id="related-content" class="hide">
+  <hr>
+  <h5><b>Related Content</b></h5>
+  <ul id="related-content-list">
+  </ul>
+</div>
+
+<span class="hide" id="full-page-url">{{- site.url -}}{{- page.permalink -}}</span>

--- a/_layouts/leftnav-page-content.html
+++ b/_layouts/leftnav-page-content.html
@@ -3,5 +3,8 @@ layout: leftnav-page
 ---
 
 <div class="content">
-    {{- content -}}
+  {{- content -}}
+  {%- if site.recommender == true -%}
+    {%- include recommender.html -%}
+  {%- endif -%}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -30,6 +30,9 @@ layout: default
     <div class="row">
       <div class="col is-8 is-offset-2 print-content">
     		{{- content -}}
+        {%- if site.recommender == true -%}
+          {%- include recommender.html -%}
+        {%- endif -%}
       </div>
       {%- include print.html -%}
     </div>

--- a/_layouts/simple-page.html
+++ b/_layouts/simple-page.html
@@ -20,6 +20,9 @@ layout: default
         <div class="row">
             <div class="col is-8 is-offset-2 print-content">
             	{{- content -}}
+              {%- if site.recommender == true -%}
+                {%- include recommender.html -%}
+              {%- endif -%}
             </div>
             {%- include print.html -%}
         </div>

--- a/assets/js/recommender.js
+++ b/assets/js/recommender.js
@@ -5,7 +5,7 @@ let NUM_RECOMMENDED_PAGES = 5
 let pageUrl = document.getElementById('full-page-url').innerHTML
 
 let param = {
-  url: unescape(window.btoa(pageUrl))
+  url: window.btoa(unescape(pageUrl))
 }
 
 let request = $.ajax({

--- a/assets/js/recommender.js
+++ b/assets/js/recommender.js
@@ -18,14 +18,14 @@ request.then(function(response) {
   let relatedPostsString = ''
   let relatedPostsDiv = document.getElementById('related-content')
   let relatedPostsList = document.getElementById('related-content-list')
-  
+
   relatedPostsDiv.classList.remove('hide')
 
   let relatedPostArray = response.recommended_posts
   let slicedArray = relatedPostArray.slice(0,NUM_RECOMMENDED_PAGES)
 
   slicedArray.forEach(function(relatedPost) {
-    relatedPostsString += '<li><a href=\"' + relatedPost.url + '\"">' + relatedPost.title + '</a></li>'
+    relatedPostsString += '<li><a href=\"' + relatedPost.url + '?utm_source=recommender\"">' + relatedPost.title + '</a></li>'
   })
 
   relatedPostsList.innerHTML = relatedPostsString

--- a/assets/js/recommender.js
+++ b/assets/js/recommender.js
@@ -1,0 +1,35 @@
+'use strict'
+
+let NUM_RECOMMENDED_PAGES = 5
+
+let pageUrl = document.getElementById('full-page-url').innerHTML
+
+let param = {
+  url: unescape(window.btoa(pageUrl))
+}
+
+let request = $.ajax({
+  url: 'https://api.isomer.gov.sg/recommend',
+  data: param,
+  dataType: 'json'
+})
+
+request.then(function(response) {
+  let relatedPostsString = ''
+  let relatedPostsDiv = document.getElementById('related-content')
+  let relatedPostsList = document.getElementById('related-content-list')
+  
+  relatedPostsDiv.classList.remove('hide')
+
+  let relatedPostArray = response.recommended_posts
+  let slicedArray = relatedPostArray.slice(0,NUM_RECOMMENDED_PAGES)
+
+  slicedArray.forEach(function(relatedPost) {
+    relatedPostsString += '<li><a href=\"' + relatedPost.url + '\"">' + relatedPost.title + '</a></li>'
+  })
+
+  relatedPostsList.innerHTML = relatedPostsString
+
+}).catch(function(error) {
+  console.log(error)
+})


### PR DESCRIPTION
This PR adds the page recommendation feature to `simple-page`, `leftnav-page-content`, and `post`.

### How it works
Each page mentioned above has a short javascript snippet that calls the `https://api.isomer.gov.sg/recommend` endpoint with a `url` parameter that contains the base64 encoding of its url.

Specifically, for example, when a user navigates to `https://www.tech.gov.sg/who-we-are/our-role/`, the javascript snippet makes a GET to `https://api.isomer.gov.sg/recommend?url=aHR0cHM6Ly93d3cudGVjaC5nb3Yuc2cvd2hvLXdlLWFyZS9vdXItcm9sZS8=`

The response object looks like this
```
{
   "recommended_posts":[
      {
         "title":"Smart Nation Sensor Platform",
         "url":"https://www.tech.gov.sg/products-and-services/smart-nation-sensor-platform/"
      },
      {
         "title":"Strategic National Projects to build a Smart Nation",
         "url":"https://www.tech.gov.sg/media/media-releases/strategic-national-projects-to-build-a-smart-nation"
      },
      {
         "title":"Transcript of Prime Minister Lee Hsien Loong's Speech at Smart Nation Launch on 24 November",
         "url":"https://www.tech.gov.sg/media/speeches/transcript-of-prime-minister-lee-hsien-loong-speech-at-smart-nation-launch-on-24-november"
      },
      ...
   ]
}
```

The javascript snippet then populates the **Related Content** section part of the page with the relevant links from the API endpoint.