### PR TITLE
Add tracker code to view where the user came from

### DIFF
--- a/assets/js/recommender.js
+++ b/assets/js/recommender.js
@@ -3,9 +3,10 @@
 let NUM_RECOMMENDED_PAGES = 5
 
 let pageUrl = document.getElementById('full-page-url').innerHTML
+let base64PageUrl = window.btoa(unescape(pageUrl))
 
 let param = {
-  url: window.btoa(unescape(pageUrl))
+  url: base64PageUrl
 }
 
 let request = $.ajax({
@@ -25,7 +26,7 @@ request.then(function(response) {
   let slicedArray = relatedPostArray.slice(0,NUM_RECOMMENDED_PAGES)
 
   slicedArray.forEach(function(relatedPost) {
-    relatedPostsString += '<li><a href=\"' + relatedPost.url + '?utm_source=recommender\"">' + relatedPost.title + '</a></li>'
+    relatedPostsString += '<li><a href=\"' + relatedPost.url + '?utm_medium=recommender&utm_source=' + base64PageUrl + '\"">' + relatedPost.title + '</a></li>'
   })
 
   relatedPostsList.innerHTML = relatedPostsString


### PR DESCRIPTION
Currently, we use `utm_source` to identify clicks on the recommended links; however, we do not know which page the user came from.

This PR adds a `utm_medium` tracker set to a value of `<base64(url)>` to track the page on which the user clicked the recommended link.