### PR TITLE
Add current URL to second-level-nav breadcrumb

### DIFF
--- a/_includes/header-breadcrumb.html
+++ b/_includes/header-breadcrumb.html
@@ -21,6 +21,7 @@
                     {%- endif -%}
                 {%- endfor -%}
             {%- endif -%}
+            <li><a href="{{- page.permalink -}}"><small>{{page.title | upcase}}</small></a></li>
         {%- else -%}
             {%- for i in (1..forLoopMaxInt) -%}
                 {%- capture current_breadcrumb_url -%}{{next_prepender}}/{{- splitted_url_parts[i] -}}/index.html{%- endcapture -%}


### PR DESCRIPTION
Currently, in the left-nav/second-level-nav pages, the breadcrumbs do not display the existing page. In the example below, users expect to also see the current page: `REQUEST A CERTIFICATE OF GOOD STANDING` as a breadcrumb.

<img width="1278" alt="Screenshot 2019-09-11 at 1 56 13 PM" src="https://user-images.githubusercontent.com/19917616/64671769-05467100-d49c-11e9-9e21-5cbe0aac0914.png">

This fix adds the current page URL to the breadcrumb.