### PR TITLE
Modify template to be compatible with collections.yml

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -29,7 +29,6 @@ layout: skeleton
 
 {%- if page.collection and page.collection != "posts" -%}
     {%- comment -%} Page is a leftnav page {%- endcomment -%}
-    {%- assign collection = site[page.collection] -%}
     <section class="bp-section padding--none is-hidden-desktop">
         <div class="bp-dropdown is-hoverable">
             <div class="bp-dropdown-trigger">
@@ -44,60 +43,69 @@ layout: skeleton
                 <div class="bp-dropdown-content">
                     {%- assign prev_third_nav_title = "" -%}
                     {%- assign in_third_nav = false -%}
+                    {%- assign collectionList = site.data.collections.collections -%}
+                    {%- for collection in collectionList -%}
+                    {%- comment -%} Loop through the collections.yml file {%- endcomment -%}
+                        {%- if collection.collection == page.collection -%}
+                        {%- comment -%} Access the correct collection {%- endcomment -%}
+                            {%- for section in collection.collectionPages -%}
+                            {%- comment -%} Loop through all sections in the collection {%- endcomment -%}
+                                {%- if section.thirdnav -%}
+                                {%- comment -%} If this is a third level nav page {%- endcomment -%}
+                                    {%- if prev_third_nav_title != section.thirdnav -%}
+                                    {%- comment -%} Since we are in a thirdnav, check if we are at the start of a new thirdnav or same as previous thirdnav {%- endcomment -%}
+                                        {%- if in_third_nav -%}
+                                            {%- comment -%} Different third nav, end previous third nav block and start new block {%- endcomment -%}
+                                            </div>
+                                        {%- endif -%}
 
-                    {%- for collection_doc in collection -%}
-                        {%- if collection_doc.third_nav_title -%}
-                            {%- comment -%} If this is a third level nav page {%- endcomment -%}
-                            {%- if prev_third_nav_title != collection_doc.third_nav_title -%}
-                                {%- if in_third_nav -%}
-                                    {%- comment -%} Different third nav, end previous third nav block and start new block {%- endcomment -%}
+                                        {%- assign anchor_colour = "" -%}
+                                        {%- assign chevron_direction = "down" -%}
+                                        {%- assign hidden = "is-hidden" -%}
+
+                                        {%- if page.third_nav_title == section.thirdnav -%}
+                                            {%- assign anchor_colour = "is-active" -%}
+                                            {%- assign chevron_direction = "up" -%}
+                                            {%- assign hidden = "" -%}
+                                        {%- endif -%}
+
+                                        <a class="bp-dropdown-item third-level-nav-header-mobile {{ anchor_colour }}">
+                                            <p>{{- section.thirdnav -}}<i class="sgds-icon sgds-icon-chevron-{{ chevron_direction }} is-pulled-right is-size-4" aria-hidden="true"></i></p>
+                                        </a>
+                                        <div class="third-level-nav-div-mobile {{ hidden }}">
+                                        {%- assign prev_third_nav_title = section.thirdnav -%}
+                                        {%- assign in_third_nav = true -%}
+                                    {%- endif -%}
+
+                                    {%- assign anchor_colour = "" -%}
+                                    {%- if page.url == section.url -%}
+                                        {%- assign anchor_colour = "has-text-secondary has-text-weight-bold" -%}
+                                    {%- endif -%}
+
+                                    <a class="bp-dropdown-item third-level-nav-item-mobile {{ anchor_colour }}" href="{{- section.url -}}">
+                                        <p>{{- section.title -}}</p>
+                                    </a>
+                                {%- else -%}
+                                {%- comment -%} If this is NOT a third level nav page {%- endcomment -%}
+                                    {%- if in_third_nav -%}
+                                        {%- comment -%} End previous third nav block {%- endcomment -%}
+                                        </div>
+                                        {%- assign in_third_nav = false -%}
+                                    {%- endif -%}
+
+                                    {%- assign anchor_colour = "" -%}
+                                    {%- if page.url == section.url -%}
+                                        {%- assign anchor_colour = "is-active" -%}
+                                    {%- endif -%}
+
+                                    <a class="bp-dropdown-item third-level-nav-item-mobile {{ anchor_colour }}" href="{{- section.url -}}">
+                                        <p>{{- section.title -}}</p>
+                                    </a>
+                                {%- endif -%}
+                                {%- if forloop.last and in_third_nav -%}
                                     </div>
                                 {%- endif -%}
-
-                                {%- assign anchor_colour = "" -%}
-                                {%- assign chevron_direction = "down" -%}
-                                {%- assign hidden = "is-hidden" -%}
-                                {%- if page.third_nav_title == collection_doc.third_nav_title -%}
-                                    {%- assign anchor_colour = "has-text-secondary has-text-weight-bold" -%}
-                                    {%- assign chevron_direction = "up" -%}
-                                    {%- assign hidden = "" -%}
-                                {%- endif -%}
-
-                                <a class="bp-dropdown-item third-level-nav-header-mobile {{ anchor_colour }}">
-                                    <p>{{- collection_doc.third_nav_title -}}<i class="sgds-icon sgds-icon-chevron-{{ chevron_direction }} is-pulled-right is-size-4" aria-hidden="true"></i></p>
-                                </a>
-                                <div class="third-level-nav-div-mobile {{ hidden }}">
-                                {%- assign prev_third_nav_title = collection_doc.third_nav_title -%}
-                                {%- assign in_third_nav = true -%}
-                            {%- endif -%}
-
-                            {%- assign anchor_colour = "" -%}
-                            {%- if page.url == collection_doc.url -%}
-                                {%- assign anchor_colour = "has-text-secondary has-text-weight-bold" -%}
-                            {%- endif -%}
-
-                            <a class="bp-dropdown-item third-level-nav-item-mobile {{ anchor_colour }}" href="{{- collection_doc.url -}}">
-                                <p>{{- collection_doc.title -}}</p>
-                            </a>
-                        {%- else -%}
-                            {%- comment -%} If this is not a third level nav page {%- endcomment -%}
-                            {%- if in_third_nav -%}
-                                {%- comment -%} End previous third nav block {%- endcomment -%}
-                                </div>
-                                {%- assign in_third_nav = false -%}
-                            {%- endif -%}
-
-                            {%- assign anchor_colour = "" -%}
-                            {%- if page.url == collection_doc.url -%}
-                                {%- assign anchor_colour = "has-text-secondary has-text-weight-bold" -%}
-                            {%- endif -%}
-
-                            <a class="bp-dropdown-item third-level-nav-item-mobile {{ anchor_colour }}" href="{{- collection_doc.url -}}">
-                                <p>{{- collection_doc.title -}}</p>
-                            </a>
-                        {%- endif -%}
-                        {%- if forloop.last and in_third_nav -%}
-                            </div>
+                            {%- endfor -%}
                         {%- endif -%}
                     {%- endfor -%}
                 </div>
@@ -114,60 +122,68 @@ layout: skeleton
                             <ul class="bp-menu-list">
                                 {%- assign prev_third_nav_title = "" -%}
                                 {%- assign in_third_nav = false -%}
+                                {%- assign collectionList = site.data.collections.collections -%}
+                                {%- for collection in collectionList -%}
+                                {%- comment -%} Loop through the collections.yml file {%- endcomment -%}    
+                                    {%- if collection.collection == page.collection -%}
+                                    {%- comment -%} Access the correct collection {%- endcomment -%}   
+                                        {%- for section in collection.collectionPages -%}
+                                        {%- comment -%} Loop through all sections in the collection {%- endcomment -%}
+                                            {%- if section.thirdnav -%}
+                                            {%- comment -%} If this is a third level nav page {%- endcomment -%}
+                                                {%- if prev_third_nav_title != section.thirdnav -%}
+                                                {%- comment -%} Since we are in a thirdnav, check if we are at the start of a new thirdnav or same as previous thirdnav {%- endcomment -%}
+                                                    {%- if in_third_nav -%}
+                                                        {%- comment -%} Different third nav, end previous third nav block and start new block {%- endcomment -%}
+                                                        </div>
+                                                    {%- endif -%}
+            
+                                                    {%- assign anchor_colour = "" -%}
+                                                    {%- assign chevron_direction = "down" -%}
+                                                    {%- assign hidden = "is-hidden" -%}
 
-                                {%- for collection_doc in site[page.collection] -%}
-                                    {%- if collection_doc.third_nav_title -%}
-                                        {%- comment -%} If this is a third level nav page {%- endcomment -%}
-                                        {%- if prev_third_nav_title != collection_doc.third_nav_title -%}
-                                            {%- if in_third_nav -%}
-                                                {%- comment -%} Different third nav, end previous third nav block and start new block {%- endcomment -%}
+                                                    {%- if page.third_nav_title == section.thirdnav -%}
+                                                        {%- assign anchor_colour = "is-active" -%}
+                                                        {%- assign chevron_direction = "up" -%}
+                                                        {%- assign hidden = "" -%}
+                                                    {%- endif -%}
+
+                                                    <li class="third-level-nav-header">
+                                                        <a class="third-level-nav-header {{ anchor_colour }}">
+                                                            {{- section.thirdnav -}}<i class="sgds-icon sgds-icon-chevron-{{ chevron_direction }} is-pulled-right is-size-4" aria-hidden="true"></i>
+                                                        </a>
+                                                    </li>
+                                                    <div class="third-level-nav-div {{ hidden }}">
+                                                    {%- assign prev_third_nav_title = section.thirdnav -%}
+                                                    {%- assign in_third_nav = true -%}
+                                                {%- endif -%}
+
+                                                {%- assign anchor_colour = "" -%}
+                                                {%- if page.url == section.url -%}
+                                                    {%- assign anchor_colour = "has-text-secondary has-text-weight-bold" -%}
+                                                {%- endif -%}
+
+                                                <li><a class="third-level-nav-item padding--top--none {{ anchor_colour }}" href="{{- section.url -}}">{{- section.title -}}</a></li>
+                                            {%- else -%}
+                                                {%- comment -%} If this is NOT a third level nav page {%- endcomment -%}
+                                                {%- if in_third_nav -%}
+                                                    {%- comment -%} End previous third nav block {%- endcomment -%}
+                                                    </div>
+                                                    {%- assign in_third_nav = false -%}
+                                                {%- endif -%}
+
+                                                {%- assign anchor_colour = "" -%}
+                                                {%- if page.url == section.url -%}
+                                                    {%- assign anchor_colour = "is-active" -%}
+                                                {%- endif -%}
+                                                <li>
+                                                    <a class="{{ anchor_colour }}" href="{{- section.url -}}">{{- section.title -}}</a>
+                                                </li>
+                                            {%- endif -%}
+                                            {%- if forloop.last and in_third_nav -%}
                                                 </div>
                                             {%- endif -%}
-
-                                            {%- assign anchor_colour = "" -%}
-                                            {%- assign chevron_direction = "down" -%}
-                                            {%- assign hidden = "is-hidden" -%}
-                                            {%- if page.third_nav_title == collection_doc.third_nav_title -%}
-                                                {%- assign anchor_colour = "is-active" -%}
-                                                {%- assign chevron_direction = "up" -%}
-                                                {%- assign hidden = "" -%}
-                                            {%- endif -%}
-
-                                            <li class="third-level-nav-header">
-                                                <a class="third-level-nav-header {{ anchor_colour }}">
-                                                    {{- collection_doc.third_nav_title -}}<i class="sgds-icon sgds-icon-chevron-{{ chevron_direction }} is-pulled-right is-size-4" aria-hidden="true"></i>
-                                                </a>
-                                            </li>
-                                            <div class="third-level-nav-div {{ hidden }}">
-                                            {%- assign prev_third_nav_title = collection_doc.third_nav_title -%}
-                                            {%- assign in_third_nav = true -%}
-                                        {%- endif -%}
-
-                                        {%- assign anchor_colour = "" -%}
-                                        {%- if page.url == collection_doc.url -%}
-                                            {%- assign anchor_colour = "has-text-secondary has-text-weight-bold" -%}
-                                        {%- endif -%}
-
-                                        <li><a class="third-level-nav-item padding--top--none {{ anchor_colour }}" href="{{- collection_doc.url -}}">{{- collection_doc.title -}}</a></li>
-                                    {%- else -%}
-                                        {%- comment -%} If this is note a third level nav page {%- endcomment -%}
-                                        {%- if in_third_nav -%}
-                                            {%- comment -%} End previous third nav block {%- endcomment -%}
-                                            </div>
-                                            {%- assign in_third_nav = false -%}
-                                        {%- endif -%}
-
-                                        {%- assign anchor_colour = "" -%}
-                                        {%- if page.url == collection_doc.url -%}
-                                            {%- assign anchor_colour = "is-active" -%}
-                                        {%- endif -%}
-
-                                        <li>
-                                            <a class="{{ anchor_colour }}" href="{{- collection_doc.url -}}">{{- collection_doc.title -}}</a>
-                                        </li>
-                                    {%- endif -%}
-                                    {%- if forloop.last and in_third_nav -%}
-                                        </div>
+                                        {%- endfor -%}
                                     {%- endif -%}
                                 {%- endfor -%}
                             </ul>
@@ -193,53 +209,63 @@ layout: skeleton
         </div>
     </section>
 
-    {%- for collection_doc in collection -%}
-        {%- if page.url == collection_doc.url -%}
-            {%- comment -%} If the page is the first in the list {%- endcomment -%}
-            {%- if forloop.first and collection[1] -%}
-                <section class="bp-section bottom-navigation">
-                    <div>
-                        <a href="{{- collection[1].url -}}" class="is-full is-right">
-                            <p class="has-text-weight-semibold">NEXT <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span></p>
-                            <p class="is-hidden-mobile">{{- collection[1].title -}}</p>
-                        </a>
-                    </div>
-                </section>
 
-            {%- comment -%} If the page is last in the list {%- endcomment -%}
-            {%- elsif forloop.last -%}
-                {%- assign prevIndex = forloop.index0 | minus: 1 -%}
-                {%- if prevIndex > 0 -%}
-                    <section class="bp-section bottom-navigation">
-                        <div>
-                            <a href="{{- collection[prevIndex].url -}}" class="is-full">
-                                <p class="has-text-weight-semibold"><span class="sgds-icon sgds-icon-arrow-left is-size-4"></span> PREVIOUS </p>
-                                <p class="is-hidden-mobile">{{- collection[prevIndex].title -}}</p>
-                            </a>
-                        </div>
-                    </section>
+
+    {%- for collection in collectionList -%}
+    {%- comment -%} Loop through the collections.yml file {%- endcomment -%}
+        {%- if collection.collection == page.collection -%}
+        {%- comment -%} Access the correct collection {%- endcomment -%}
+            {%- for section in collection.collectionPages -%}
+            {%- comment -%} Loop through all sections in the collection {%- endcomment -%}
+                {%- if page.url == section.url -%}
+                {%- comment -%} check that we have the right page, since we want to determine the pages that come before and after it in the bottom nav {%- endcomment -%}
+                    {%- if forloop.first and collection.collectionPages[1] -%}
+                    {%- comment -%} checks that we are at the first page in the collection, and that there is at least a second page {%- endcomment -%}
+                        <section class="bp-section bottom-navigation">
+                            <div>
+                                <a href="{{- collection.collectionPages[1].url -}}" class="is-full is-right">
+                                    <p class="has-text-weight-semibold">NEXT <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span></p>
+                                    <p class="is-hidden-mobile">{{- collection.collectionPages[1].title -}}</p>
+                                </a>
+                            </div>
+                        </section>
+
+                    {%- elsif forloop.last -%}
+                    {%- comment -%} checks that we are at the last page in the collection, and that there is at least a second page {%- endcomment -%}
+                        {%- assign prevIndex = collection.collectionPages.size | minus: 2 -%}
+                        {%- if prevIndex > 0 -%}
+                            <section class="bp-section bottom-navigation">
+                                <div>
+                                    <a href="{{- collection.collectionPages[prevIndex].url -}}" class="is-full">
+                                        <p class="has-text-weight-semibold"><span class="sgds-icon sgds-icon-arrow-left is-size-4"></span> PREVIOUS </p>
+                                        <p class="is-hidden-mobile">{{- collection.collectionPages[prevIndex].title -}}</p>
+                                    </a>
+                                </div>
+                            </section>
+                        {%- endif -%}
+                    {%- else -%}
+                    {%- comment -%} for all the intermediate pages {%- endcomment -%}
+                        {%- assign prevIndex = forloop.index0 | minus: 1 -%}
+                        {%- assign nextIndex = forloop.index0 | plus: 1 -%}
+
+                        <section class="bp-section bottom-navigation">
+                            <div>
+                                <a href="{{- collection.collectionPages[prevIndex].url -}}" class="is-half is-left">
+                                    <p class="has-text-weight-semibold"><span class="sgds-icon sgds-icon-arrow-left is-size-4"></span> PREVIOUS </p>
+                                    <p class="is-hidden-mobile">{{- collection.collectionPages[prevIndex].title -}}</p>
+                                </a>
+                                <a href="{{- collection.collectionPages[nextIndex].url -}}" class="is-half is-right">
+                                    <p class="has-text-weight-semibold">NEXT <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span></p>
+                                    <p class="is-hidden-mobile">{{- collection.collectionPages[nextIndex].title -}}</p>
+                                </a>
+                            </div>
+                        </section>
+                    {%- endif -%}
                 {%- endif -%}
-            {%- comment -%} For all other intermediate pages in the list {%- endcomment -%}
-            {%- else -%}
-                {%- assign prevIndex = forloop.index0 | minus: 1 -%}
-                {%- assign nextIndex = forloop.index0 | plus: 1 -%}
-
-                <section class="bp-section bottom-navigation">
-                    <div>
-                        <a href="{{- collection[prevIndex].url -}}" class="is-half is-left">
-                            <p class="has-text-weight-semibold"><span class="sgds-icon sgds-icon-arrow-left is-size-4"></span> PREVIOUS </p>
-                            <p class="is-hidden-mobile">{{- collection[prevIndex].title -}}</p>
-                        </a>
-                        <a href="{{- collection[nextIndex].url -}}" class="is-half is-right">
-                            <p class="has-text-weight-semibold">NEXT <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span></p>
-                            <p class="is-hidden-mobile">{{- collection[nextIndex].title -}}</p>
-                        </a>
-                    </div>
-                </section>
-            {%- endif -%}
-            {%- break -%}
+            {%- endfor -%}
         {%- endif -%}
     {%- endfor -%}
+
 {%- else -%}
     {%- comment -%} Page is a simple page {%- endcomment -%}
     <section class="bp-section">


### PR DESCRIPTION
**Note:** We should not merge this pull request right away since this will break compatibility for all existing V2 sites which are dependent on the `next-gen` branch.

**Context**
Right now, the way pages in collections are rendered is dependent on the collection pages’ file name. For example, this is a sample collection folder Careers:
```
Careers
- 0-join-us.md
- 1-why-join-us.md
- 2a-we-are-rich.md
- 2b-you-are-poor.md
- 3-game-set-match.md
```

Collections’ pages are rendered using the layout page.html. When Jekyll builds the website, it has access to each collection and the pages in them. This allows the user to loop through the collection’s pages using a for loop. For example, this for loop allows us to generate the left navigation bar for pages in collections.

However, we cannot choose the order in which the files are looped through. They are simply looped through in the order in which they exist - that is, in alphanumeric order. Therefore, in order to manipulate the order of the loop, the original Isomer setup was to name the files in the alphanumeric order you wish for them to be displayed in the collection. That means that the above sample collection folder will render equivalently even with the following file names:
```
Careers
- 1-join-us.md
- 1a-why-join-us.md
- 1b-we-are-rich.md
- 1c-you-are-poor.md
- 3-game-set-match.md
```

**Problem**
We run into a problem while developing our CMS. We are developing a drag and drop accordion menu for users to easily access their files in a hierarchical manner, and also for them to easily change the order of the collections and the order of the pages in the collections in the navigation bar. 

Reordering the collections alone is simple - all the data required for this is found in `navigation.yml`. We simply need to reorder the YAML elements in `navigation.yml`.

The problem arises when trying to reorder collection pages. There are two scenarios:
Reordering of page within a collection
Dragging a page from one collection to another

Since the appearance of the left navigation bar is dependent on the file names in the collection, there is a high chance that either operation mentioned above will be incompatible with the pre-existing alphanumeric order that already exists. For example, imagine a second collection, Offices:
```
Offices
- 0-where-we-are.md
- 1-where-we-go.md
- 2-why-you-should-come.md
```

If you now want `2-why-you-should-come.md` to belong to the Careers collection and not the Offices collection, and you want it to appear at as the first page in the Careers collection. You can try to drag it to the Careers collection, but this is what the Careers collection will look like. 
```
Careers
- 0-join-us.md
- 1-why-join-us.md
- 2-why-you-should-come.md
- 2a-we-are-rich.md
- 2b-you-are-poor.md
- 3-game-set-match.md
```

Instead of appearing as the first page, it will appear as the third page. To get it in the order we want, we should rename all the files so that Careers looks like this:
```
Careers
- 0-why-you-should-come.md
- 1-join-us.md
- 2-why-join-us.md
- 3a-we-are-rich.md
- 3b-you-are-poor.md
- 4-game-set-match.md
```

But to do this means that we need to rename many files every time a file is reordered. Each file rename is time consuming in the current CMS setup as we have to delete and create a new file for each renamed file. More significantly, the logic required to keep track of which file to rename and what to name it can get very complicated.

**Proposed solution**
By concerning ourselves only with collections, we don’t have to worry about other Isomer templates/layouts, we only need to look at `page.html` (formerly `left-navpage-content`). We can create a new YAML file (`collections.yml`) that is only utilized in `page.html`. This separates the operations completely from the rest of the pages (non-left nav pages).

We will modify the page.html layout to read directly from the `collections.yml` file when dealing with collections pages. This means that whenever a file is reordered, we do not need to change the ordering of the files in the Github repo, or rename them. We simply overwrite the existing `collections.yml` file with the correct order, reducing the number of API calls we need to do from 2N (where N is the number of collections which have reordered pages) to 1 call (an update to `collections.yml`).

A sample `collections.yml` file is shown below:
```
collections:
  - title: About
    collection: about
    collectionPages:
      - title: About The Prize
        url: /about/about-the-prize/
        filepath: _about/0-about-the-prize.md
      - title: Prize Council
        url: /about/prize-jury/prize-council
        thirdnav: Prize Jury 
        filepath: _about/1a-prize-council.md
      - title: Nominating committee
        thirdnav: Prize Jury 
        url: /about/prize-jury/nominating-committee
        filepath: _about/1b-nominating-committee.md
     - title: Prize partners
        url: /about/prize-partners/
        filepath: _about/2-prize-partners.md
  - title: Nomination
    collection: nomination
    collectionPages:
      - title: Chairman's Message
        url: /nomination/chairmans-message/
        filepath: _nomination/0-chairmans-message.md
      - title: How to Nominate?
        url: /nomination/guidelines/overview/
        thirdnav: Nomination Guidelines
        filepath: _nomination/1a-nominations-overview.md
      - title: Stage A Nomination
        url: /nomination/guidelines/stage-a/
        thirdnav: Nomination Guidelines
        filepath: _nomination/1b-stage-a-nomination.md
      - title: Stage B Submission
        url: /nomination/guidelines/stage-b/
        filepath: _nomination/1c-stage-b-nomination.md
        thirdnav: Nomination Guidelines
      - title: Judging Criteria
        url: /nomination/judging-criteria/
        filepath: _nomination/2-judging-criteria.md
```