### PR TITLE
Next gen mainscript post fix

### DIFF
--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -52,7 +52,7 @@
 <script src="{{- "/assets/js/paginate-resources.js" | relative_url -}}" crossorigin="anonymous"></script>
 {%- endif -%}
 
-{%- if page.layout == 'page' or page.layout == 'our-team' or page.layout == 'our-journey' -%}
+{%- if page.layout == 'page' or page.layout == 'our-team' or page.layout == 'our-journey' -% or page.layout == 'post'}
 <script src="https://printjs-4de6.kxcdn.com/print.min.js" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/floating-buttons.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/left-nav-interaction.js" | relative_url -}}" crossorigin="anonymous"></script>

--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -52,7 +52,7 @@
 <script src="{{- "/assets/js/paginate-resources.js" | relative_url -}}" crossorigin="anonymous"></script>
 {%- endif -%}
 
-{%- if page.layout == 'page' or page.layout == 'our-team' or page.layout == 'our-journey' -% or page.layout == 'post'}
+{%- if page.layout == 'page' or page.layout == 'our-team' or page.layout == 'our-journey' or page.layout == 'post' -%}
 <script src="https://printjs-4de6.kxcdn.com/print.min.js" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/floating-buttons.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/left-nav-interaction.js" | relative_url -}}" crossorigin="anonymous"></script>


### PR DESCRIPTION
Many v2 sites have the following in the front matter of the resources in their resource room:

`layout : post`

This is because when generating a site using generate-site.py, the program adds this line in the sample resource that is generated. The users of the repository then copy this front matter and use it for other posts.

In main_script.html, the segment that includes the source for printing is only available if the layouts are 'page', 'our-team' and 'our-journey'. This causes the print icon to not work on resource pages. [An example of this happening](https://www.sgunited.gov.sg/community-in-action/community-initiatives/five-calls)

This pull request is to include the layout 'post' into the if-statement in main_script.html that includes the source for the print function.