### PR TITLE
fix: mail function broken in v2

### DIFF
--- a/assets/js/floating-buttons.js
+++ b/assets/js/floating-buttons.js
@@ -17,7 +17,7 @@ const fullUrl = window.location.href;
 const fullUrlEncoded = encodeURIComponent(window.location.href);
 const titleEncoded = encodeURIComponent(document.getElementsByTagName("title")[0].innerHTML);
 
-document.getElementById("mail-anchor").setAttribute("href", "mailto:?Subject=" + titleEncoded + "&amp;Body=" + fullUrlEncoded);
+document.getElementById("mail-anchor").setAttribute("href", "mailto:?Subject=" + titleEncoded + "&Body=" + fullUrlEncoded);
 document.getElementById("fb-anchor").setAttribute("href", "http://www.facebook.com/sharer.php?u=" + fullUrlEncoded);
 document.getElementById("li-anchor").setAttribute("href", "https://www.linkedin.com/sharing/share-offsite/?url=" + fullUrlEncoded + "&title=" + titleEncoded);
 document.getElementById("page-url").setAttribute("value", fullUrl);


### PR DESCRIPTION
Mail function in v2 websites don't work. There is no content in the body of the email, only a subject.

This is because of the changes made to the floating-buttons.js file. It was made to ensure the email function worked even if the client did not fill up the url in their repository's _config.yml.

Javascript files do not need to include character references like '&amp;' in its html strings. If included, it breaks the href tag.

![image](https://user-images.githubusercontent.com/20721527/74903101-f963c100-53e2-11ea-8a41-7f89618801e8.png)
Notice the end of the first line. "&amp;" is taken literally instead of being converted into just "&".

Replacing the "&amp;" with just "&" fixes this issue.