### PR TITLE
feat: google tag manager on v1 isomer sites

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -46,6 +46,8 @@
         <script src="{{- "assets/js/facebook-pixel.js" | relative_url -}}" crossorigin="anonymous"></script>
         <noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id={{- site.facebook-pixel -}}&ev=PageView&noscript=1"/></noscript>
     {%- endif -%}
-
+    {%- if site.google-tag-manager -%}
+        <script src="{{- "assets/js/google-tag-manager.js" | relative_url -}}" crossorigin="anonymous"></script>
+    {%- endif -%}
     <title>{{- page.title | strip_html -}}</title>
 </head>

--- a/assets/js/google-tag-manager.js
+++ b/assets/js/google-tag-manager.js
@@ -1,0 +1,8 @@
+---
+layout: blank
+---
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{- site.google-tag-manager -}}');


### PR DESCRIPTION
Some clients have been bringing up plans about incorporating google tag manager on their websites.

This PR provides clients with the ability to insert a google tag manager ID in their config.yml to activate google tag manager on their v1 Isomer website.