### PR TITLE
fix: prevent content from going offscreen in a column

### DIFF
--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -6888,6 +6888,7 @@ a.navbar-link.is-active {
     flex-grow: 1;
     flex-shrink: 1;
     padding: 0.75rem;
+    max-width: 100%;
 }
 .col.has-carousel {
     min-width: 0;


### PR DESCRIPTION
This fix adds a new attribute, "max-width:100%", to the col class to prevent content from extending beyond the screen.

![image](https://user-images.githubusercontent.com/20721527/76595976-fff3dd00-6537-11ea-9cc6-f1fbe93e6e5d.png)
