### PR TITLE
fix: prevent content from going offscreen in a column

### DIFF
--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -6891,6 +6891,7 @@ a.navbar-link.is-active {
     flex-grow: 1;
     flex-shrink: 1;
     padding: 0.75rem;
+    max-width: 100%;
 }
 .col.has-carousel {
     min-width: 0;


### PR DESCRIPTION
This fix adds a new attribute, "max-width:100%", to the col class to prevent content from extending beyond the screen.

![image](https://user-images.githubusercontent.com/20721527/76596042-2ca7f480-6538-11ea-9351-1144f085ee20.png)
