### PR TITLE
chore: update jquery to v3.5.0

### DIFF
--- a/_includes/main-scripts.html
+++ b/_includes/main-scripts.html
@@ -1,6 +1,6 @@
 {%- comment -%} DYN {%- endcomment -%}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js" integrity="sha256-0rguYS0qgS6L4qVzANq4kjxPLtvnp5nn2nB5G1lWRv4=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.0/jquery.min.js" integrity="sha384-JUMjoW8OzDJw4oFpWIB2Bu/c6768ObEthBMVSiIx4ruBIEdyNSUQAjJNFqT5pnJ6" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.0/jquery.min.js" integrity="sha384-LVoNJ6yst/aLxKvxwp6s2GAabqPczfWh6xzm38S/YtjUyZ+3aTKOnD/OJVGYLZDl" crossorigin="anonymous"></script>
 {%- comment -%} Carousel {%- endcomment -%}
 {%- if page.layout == 'homepage' -%}
   {%- if site.homepage_programmes == true or site.homepage_careers == true -%}


### PR DESCRIPTION
This PR updates the jQuery library that Isomer uses to `3.5.0` because there is a known XSS vulnerability: https://snyk.io/vuln/npm:jquery.