### PR TITLE
chore: update jquery to v3.5.0 for next-gen template

### DIFF
--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -1,7 +1,7 @@
 {%- comment -%} DYN {%- endcomment -%}
 <script src=https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.8.3/polyfill.min.js></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js" integrity="sha256-0rguYS0qgS6L4qVzANq4kjxPLtvnp5nn2nB5G1lWRv4=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha384-vk5WoKIaW/vJyUAd9n/wmopsmNhiy+L2Z+SBxGYnUkunIxVxAv/UtMOhba/xskxh" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.0/jquery.min.js" integrity="sha384-LVoNJ6yst/aLxKvxwp6s2GAabqPczfWh6xzm38S/YtjUyZ+3aTKOnD/OJVGYLZDl" crossorigin="anonymous"></script>
 {%- comment -%} Carousel {%- endcomment -%}
 {%- if page.layout == "homepage" and page.sections -%}
   {%- for section in page.sections -%}


### PR DESCRIPTION
This PR updates the jQuery library that Isomer uses to 3.5.0 because there is a known XSS vulnerability: https://snyk.io/vuln/npm:jquery. This PR is specifically for the **next-gen** template.