### PR TITLE
Introduce showcase as homepage insert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 .DS_Store
 node_modules
 .jekyll-metadata
+.jekyll-cache

--- a/_includes/homepage/showcase.html
+++ b/_includes/homepage/showcase.html
@@ -1,45 +1,41 @@
-<section class="bp-section" style="background-color:#6031b6" id="showcase">
+<section class="bp-section {{ gray_container_class }}">
     <div class="bp-container padding--bottom--lg">
         <div class="row">
             <div class="col is-8 is-offset-2 has-text-centered padding--top--xl">
-                <p class="padding--bottom eyebrow is-uppercase has-text-white">
-                    SHOWCASE
+                <p class="padding--bottom eyebrow is-uppercase">
+                    {{ section.showcase.subtitle }}
                 </p>
-                <h1 class="padding--bottom has-text-white"><b>Websites generated using Isomer</b></h1>
-                <p class="has-text-white">Our websites are compliant-by-design, so that you can focus on your content</p>
+                <h1 class="has-text-secondary padding--bottom"><b>{{ section.showcase.title }}</b></h1>
+                <p>{{ section.showcase.description }}</p>
             </div>
         </div>
-        <div class="row has-text-centered margin--top padding--bottom">
-            <div class="col is-one-third">
-                <a href="https://www.hlb.gov.sg" target="_blank" class="is-media-card">
-                    <div class="image-hoverable">
-                        <img class="isomer-example" src="{{ site.baseurl }}/images/hlb-example.png" />
-                        <div class="image-hover-overlay"></div>
-                        <div class="bp-button is-white is-outlined is-uppercase image-hover-button search-button">Visit Site</div>
+        <div class="row has-text-centered margin--top padding--bottom showcase showcase-{{ section.showcase.colcount }}">
+            {%- for entry in section.showcase.entries -%}
+            <div class="col">
+                {%- if entry.url -%}
+                {%- assign url_input = entry.url -%}
+                {%- include functions/external_url.html -%}
+                <a {{anchor}} class="is-media-card" target="_blank">
+                {%- endif -%}
+                <div class="image-hoverable">
+                    <img src="{{ site.baseurl }}{{ entry.image }}" />
+                    <div class="image-hover-overlay">
+                        <div class="image-hover-overlay-container">
+                            {%- if entry.description -%}
+                            <div>{{ entry.description }}</div>
+                            {%- endif -%}
+                            {%- if entry.button -%}
+                            <div class="bp-button is-outlined is-uppercase search-button">{{ entry.button }}</div>
+                            {%- endif -%}
+                        </div>
                     </div>
+                </div>
+                {%- if entry.url -%}
                 </a>
-                <h5 class="padding--top--sm has-text-white"><b>Hotels Licensing Board</b></h5>
+                {%- endif -%}
+                <h5 class="padding--top--sm"><b>{{ entry.title }}</b></h5>
             </div>
-            <div class="col is-one-third">
-                <a href="https://www.strategygroup.gov.sg/" target="_blank" class="is-media-card">
-                    <div class="image-hoverable">
-                        <img class="isomer-example" src="{{ site.baseurl }}/images/stratgroup-example.png" />
-                        <div class="image-hover-overlay"></div>
-                        <div class="bp-button is-white is-outlined is-uppercase image-hover-button search-button">Visit Site</div>
-                    </div>
-                </a>
-                <h5 class="padding--top--sm has-text-white"><b>Strategy Group</b></h5>
-            </div>
-            <div class="col is-one-third">
-                <a href="https://www.boa.gov.sg" target="_blank" class="is-media-card">
-                    <div class="image-hoverable">
-                        <img class="isomer-example" src="{{ site.baseurl }}/images/boa-example.png" />
-                        <div class="image-hover-overlay"></div>
-                        <div class="bp-button is-white is-outlined is-uppercase image-hover-button search-button">Visit Site</div>
-                    </div>
-                </a>
-                <h5 class="padding--top--sm has-text-white"><b>Board of Architects</b></h5>
-            </div>
+            {%- endfor -%}
         </div>
     </div>
 </section>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -72,6 +72,11 @@ layout: skeleton
 		{%- include functions/swap_container_class.html -%}
 	{%- endif -%}
 
+	{%- if section.showcase -%}
+		{%- include homepage/showcase.html -%}
+		{%- include functions/swap_container_class.html -%}
+	{%- endif -%}
+
 	{%- if section.secondary_cta -%}
 		{%- include homepage/secondary_cta.html -%}
 		{%- include functions/swap_container_class.html -%}

--- a/do-not-touch/theme-colors/custom.scss
+++ b/do-not-touch/theme-colors/custom.scss
@@ -408,6 +408,42 @@ table.table-h {
   opacity: 0;
 }
 
+.showcase {
+  display: flex !important;
+  flex-wrap: wrap;
+  justify-content: center;
+  @include mobile() {
+    .col {
+      flex: 0 0 100% !important;
+    } 
+  }
+  &-1 {
+    .col {
+      flex: 0 0 100%;
+    } 
+  }
+  &-2 {
+    .col {
+      flex: 0 0 50%;
+    } 
+  }
+  &-3 {
+    .col {
+      flex: 0 0 33.3333%;
+    } 
+  }
+  &-4 {
+    .col {
+      flex: 0 0 25%;
+    } 
+  }
+  &-5 {
+    .col {
+      flex: 0 0 20%;
+    } 
+  }
+}
+
 .image-hover-overlay {
   position: absolute;
   top: 0;
@@ -415,11 +451,27 @@ table.table-h {
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0);
-  transition: background 0.5s ease;
+  transition: background 0.3s ease;
+
+  .image-hover-overlay-container {
+    position: absolute;
+    z-index: 1;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%,-50%);
+    opacity: 0;
+    color: black;
+    .bp-button {
+      margin-top: 0.5rem;
+    }
+  }
 
   &:hover{
-    background: #6031b6;
+    background: white;
     opacity: 0.9;
+    .image-hover-overlay-container {
+      opacity: 1;
+    }
   }
 }
 

--- a/index.md
+++ b/index.md
@@ -37,6 +37,37 @@ sections:
         subtitle: "It's beautiful and fast!"
         button: Contact Us
         url: https://www.opendoc.sg/
+    - showcase:
+        title: Title Text
+        subtitle: Category
+        description: A long description of what this section is about
+        colcount: 3
+        entries:
+           - url: https://www.google.com
+             image: /images/ndi-logo.jpg
+             description: Some Role
+             button: Learn More
+             title: Entry Title
+           - url: https://www.google.com
+             image: /images/ndi-logo.jpg
+             description: Some Role
+             button: Learn More
+             title: Entry Title
+           - url: https://www.google.com
+             image: /images/ndi-logo.jpg
+             description: Some Role
+             button: Learn More
+             title: Entry Title
+           - url: https://www.google.com
+             image: /images/ndi-logo.jpg
+             description: Some Role
+             button: Learn More
+             title: Entry Title
+           - url: https://www.google.com
+             image: /images/ndi-logo.jpg
+             description: Some Role
+             button: Learn More
+             title: Entry Title
     - infopic:
         title: Hey there!
         subtitle: "Lorem ipsum!"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10572368/80949190-19255580-8e26-11ea-89a0-bb694c77c142.png)

- Rework showcase.html so that it generates items from a given yaml
  config in a manner similar to the showcase in the main Isomer site
- Add CSS to style up the overlay, arrange showcase items into
  flexbox with 1-5 items per row if desktop, 1 item per row if mobile
- Insert showcase yaml config into index.md

TODO: add new css classes to site generator template