### PR TITLE
Accessibility Fixes for Isomer Template (Next-Gen)

### DIFF
--- a/_includes/agencyhead.html
+++ b/_includes/agencyhead.html
@@ -148,7 +148,7 @@
                         </div>
                     {%- else -%}
                         {%- comment -%} Single page {%- endcomment -%}
-                        <li class="navbar-item">
+                        <div class="navbar-item">
                             {%- assign url_input = navitem.url -%}
                             {%- include functions/external_url.html -%}
                             <a {{anchor}} class="navbar-item is-uppercase" style="height:100%;width:100%;">
@@ -161,7 +161,7 @@
                             {%- endif -%}
 
                             <div class="selector is-hidden-touch is-hidden-desktop-only{{active}}"></div>
-                        </li>
+                        </div>
                     {%- endif -%}
                 {%- endfor -%}
             </div>

--- a/_includes/print.html
+++ b/_includes/print.html
@@ -1,14 +1,14 @@
 <div class="col is-1 has-float-btns is-position-relative is-hidden-touch">
     <div class="float-buttons">
         <div class="actionbar__inner">
-            <button class="bp-button" id="print-button">
+            <button class="bp-button" id="print-button" aria-label="Print">
               <i 
               class="sgds-icon sgds-icon-print is-size-4">
               </i>
             </button>
         </div>
         <div class="actionbar__inner padding--top--sm">
-            <button class="bp-button" id="copy-link">
+            <button class="bp-button" id="copy-link" aria-label="Copy Link">
               <i 
               class="sgds-icon sgds-icon-link is-size-4">
               </i>
@@ -17,30 +17,24 @@
             {%- comment -%} The only cross-browser compatible way to copy the current page url into a clipboard is to store it in a hidden input box {%- endcomment -%}
         </div>
         <div class="actionbar__inner padding--top--sm">
-            <a href="mailto:?Subject={{page.title}}&amp;Body= {{page.url|absolute_url}}" id="mail-anchor">
-            <button class="bp-button">
+            <a href="mailto:?Subject={{page.title}}&amp;Body= {{page.url|absolute_url}}" id="mail-anchor" aria-label="Mail">
             <i 
               class="sgds-icon sgds-icon-mail is-size-4">
             </i>
-            </button>
             </a>
         </div>
         <div class="actionbar__inner padding--top--sm">
-            <a href="http://www.facebook.com/sharer.php?u={{page.url|absolute_url|escape}}" target="_blank" id="fb-anchor">
-            <button class="bp-button">
+            <a href="http://www.facebook.com/sharer.php?u={{page.url|absolute_url|escape}}" target="_blank" id="fb-anchor" aria-label="Share in facebook">
               <i 
               class="sgds-icon sgds-icon-facebook-alt is-size-4">
               </i>
-            </button>
             </a>
         </div>
         <div class="actionbar__inner padding--top--sm">
-            <a href="https://www.linkedin.com/sharing/share-offsite/?url={{page.url|absolute_url|escape}}&title={{page.title}}" target="_blank" id="li-anchor">
-            <button class="bp-button">
+            <a href="https://www.linkedin.com/sharing/share-offsite/?url={{page.url|absolute_url|escape}}&title={{page.title}}" target="_blank" id="li-anchor" aria-label="Share in LinkedIn">
               <i 
               class="sgds-icon sgds-icon-linkedin-alt is-size-4">
               </i>
-            </button>
             </a>
         </div>
     </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -132,12 +132,13 @@ layout: skeleton
                                                 {%- assign chevron_direction = "up" -%}
                                                 {%- assign hidden = "" -%}
                                             {%- endif -%}
-
-                                            <li class="third-level-nav-header">
-                                                <a class="third-level-nav-header {{ anchor_colour }}">
-                                                    {{- collection_doc.third_nav_title -}}<i class="sgds-icon sgds-icon-chevron-{{ chevron_direction }} is-pulled-right is-size-4" aria-hidden="true"></i>
-                                                </a>
-                                            </li>
+                                            <ul class="bp-menu-list">
+                                                <li class="third-level-nav-header">
+                                                    <a class="third-level-nav-header {{ anchor_colour }}">
+                                                        {{- collection_doc.third_nav_title -}}<i class="sgds-icon sgds-icon-chevron-{{ chevron_direction }} is-pulled-right is-size-4" aria-hidden="true"></i>
+                                                    </a>
+                                                </li>
+                                            </ul>
                                             <li>
                                                 <div class="third-level-nav-div {{ hidden }}">
                                             {%- assign prev_third_nav_title = collection_doc.third_nav_title -%}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -121,7 +121,8 @@ layout: skeleton
                                         {%- if prev_third_nav_title != collection_doc.third_nav_title -%}
                                             {%- if in_third_nav -%}
                                                 {%- comment -%} Different third nav, end previous third nav block and start new block {%- endcomment -%}
-                                                </div><ul class="bp-menu-list">
+                                                </ul>    
+                                                    </div><ul class="bp-menu-list">
                                             {%- endif -%}
 
                                             {%- assign anchor_colour = "" -%}
@@ -139,6 +140,7 @@ layout: skeleton
                                             </li>
                                             </ul>
                                             <div class="third-level-nav-div {{ hidden }}">
+                                                <ul class="bp-menu-list">
                                             {%- assign prev_third_nav_title = collection_doc.third_nav_title -%}
                                             {%- assign in_third_nav = true -%}
                                         {%- endif -%}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -121,8 +121,7 @@ layout: skeleton
                                         {%- if prev_third_nav_title != collection_doc.third_nav_title -%}
                                             {%- if in_third_nav -%}
                                                 {%- comment -%} Different third nav, end previous third nav block and start new block {%- endcomment -%}
-                                                </div>
-                                                </li>
+                                                </div></li>
                                             {%- endif -%}
 
                                             {%- assign anchor_colour = "" -%}
@@ -139,7 +138,8 @@ layout: skeleton
                                                     {{- collection_doc.third_nav_title -}}<i class="sgds-icon sgds-icon-chevron-{{ chevron_direction }} is-pulled-right is-size-4" aria-hidden="true"></i>
                                                 </a>
                                             </li>
-                                            <div class="third-level-nav-div {{ hidden }}"><li>
+                                            <li>
+                                                <div class="third-level-nav-div {{ hidden }}">
                                             {%- assign prev_third_nav_title = collection_doc.third_nav_title -%}
                                             {%- assign in_third_nav = true -%}
                                         {%- endif -%}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -122,6 +122,7 @@ layout: skeleton
                                             {%- if in_third_nav -%}
                                                 {%- comment -%} Different third nav, end previous third nav block and start new block {%- endcomment -%}
                                                 </div>
+                                                </li>
                                             {%- endif -%}
 
                                             {%- assign anchor_colour = "" -%}
@@ -138,7 +139,7 @@ layout: skeleton
                                                     {{- collection_doc.third_nav_title -}}<i class="sgds-icon sgds-icon-chevron-{{ chevron_direction }} is-pulled-right is-size-4" aria-hidden="true"></i>
                                                 </a>
                                             </li>
-                                            <div class="third-level-nav-div {{ hidden }}">
+                                            <div class="third-level-nav-div {{ hidden }}"><li>
                                             {%- assign prev_third_nav_title = collection_doc.third_nav_title -%}
                                             {%- assign in_third_nav = true -%}
                                         {%- endif -%}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -134,7 +134,7 @@ layout: skeleton
                                             {%- endif -%}
 
                                             <li class="third-level-nav-header">
-                                                <a class="third-level-nav-header {{ anchor_colour }}">
+                                                <a class="third-level-nav-header {{ anchor_colour }}" aria-label="{{- collection_doc.third_nav_title -}}">
                                                     {{- collection_doc.third_nav_title -}}<i class="sgds-icon sgds-icon-chevron-{{ chevron_direction }} is-pulled-right is-size-4" aria-hidden="true"></i>
                                                 </a>
                                             </li>
@@ -161,10 +161,11 @@ layout: skeleton
                                         {%- if page.url == collection_doc.url -%}
                                             {%- assign anchor_colour = "is-active" -%}
                                         {%- endif -%}
-
-                                        <li>
-                                            <a class="{{ anchor_colour }}" href="{{- collection_doc.url -}}">{{- collection_doc.title -}}</a>
-                                        </li>
+                                        <ul>
+                                            <li>
+                                                <a class="{{ anchor_colour }}" href="{{- collection_doc.url -}}">{{- collection_doc.title -}}</a>
+                                            </li>
+                                        </ul>
                                     {%- endif -%}
                                     {%- if forloop.last and in_third_nav -%}
                                         </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -121,7 +121,7 @@ layout: skeleton
                                         {%- if prev_third_nav_title != collection_doc.third_nav_title -%}
                                             {%- if in_third_nav -%}
                                                 {%- comment -%} Different third nav, end previous third nav block and start new block {%- endcomment -%}
-                                                </div></li>
+                                                </div><ul class="bp-menu-list">
                                             {%- endif -%}
 
                                             {%- assign anchor_colour = "" -%}
@@ -132,15 +132,13 @@ layout: skeleton
                                                 {%- assign chevron_direction = "up" -%}
                                                 {%- assign hidden = "" -%}
                                             {%- endif -%}
-                                            <ul class="bp-menu-list">
-                                                <li class="third-level-nav-header">
-                                                    <a class="third-level-nav-header {{ anchor_colour }}">
-                                                        {{- collection_doc.third_nav_title -}}<i class="sgds-icon sgds-icon-chevron-{{ chevron_direction }} is-pulled-right is-size-4" aria-hidden="true"></i>
-                                                    </a>
-                                                </li>
+                                            <li class="third-level-nav-header">
+                                                <a class="third-level-nav-header {{ anchor_colour }}">
+                                                    {{- collection_doc.third_nav_title -}}<i class="sgds-icon sgds-icon-chevron-{{ chevron_direction }} is-pulled-right is-size-4" aria-hidden="true"></i>
+                                                </a>
+                                            </li>
                                             </ul>
-                                            <li>
-                                                <div class="third-level-nav-div {{ hidden }}">
+                                            <div class="third-level-nav-div {{ hidden }}">
                                             {%- assign prev_third_nav_title = collection_doc.third_nav_title -%}
                                             {%- assign in_third_nav = true -%}
                                         {%- endif -%}

--- a/_layouts/skeleton.html
+++ b/_layouts/skeleton.html
@@ -5,7 +5,7 @@
     <body>
         {%- include agencyhead.html -%}
         {%- comment -%} onclick is needed for iOS Safari to treat stuff other than <a> tags etc (e.g. div) as clickable {%- endcomment -%}
-        <div id="main-content" onclick>
+        <div id="main-content" role="main" onclick>
         	{{- content -}}
     	</div>
         {%- include footer.html -%}


### PR DESCRIPTION
This PR fixes some of the major accessibility issues reflected [here](https://public.tableau.com/profile/zui.young.lim3934#!/vizhome/A11yTestResultsPrototype0_1-isomer_gov_sg/isomer_gov_sg) for the isomer.gov.sg website.

While not all the issues are fixed, the notably ones that are the following:
- Print, Share, Mail, Facebook, Linkedin no longer have <button> tags. These were already anchor tags so it was redundant for them to have button tags as well
- Print, Share, Mail, Facebook, Linkedin also have aria tags now.
- Unordered lists and ordered lists should now only contain <li> items.