### PR TITLE
fix: hide the related content header if there are no recommendations

### DIFF
--- a/assets/js/recommender.js
+++ b/assets/js/recommender.js
@@ -20,17 +20,21 @@ request.then(function(response) {
   let relatedPostsDiv = document.getElementById('related-content')
   let relatedPostsList = document.getElementById('related-content-list')
 
-  relatedPostsDiv.classList.remove('hide')
-
   let relatedPostArray = response.recommended_posts
   let slicedArray = relatedPostArray.slice(0,NUM_RECOMMENDED_PAGES)
 
-  slicedArray.forEach(function(relatedPost, index) {
-    const base64RelatedPost = window.btoa(unescape(encodeURIComponent(relatedPost.url)))
-    relatedPostsString += '<li><a href=\"' + relatedPost.url + '?utm_medium=recommender_' + index + '&utm_source=' + base64PageUrl + '&utm_content=' + base64RelatedPost + '\"">' + relatedPost.title + '</a></li>'
-  })
+  if (slicedArray.length > 0) {
+    // Display 'Related Content' header
+    relatedPostsDiv.classList.remove('hide')
 
-  relatedPostsList.innerHTML = relatedPostsString
+    // Display related links
+    slicedArray.forEach(function(relatedPost, index) {
+      const base64RelatedPost = window.btoa(unescape(encodeURIComponent(relatedPost.url)))
+      relatedPostsString += '<li><a href=\"' + relatedPost.url + '?utm_medium=recommender_' + index + '&utm_source=' + base64PageUrl + '&utm_content=' + base64RelatedPost + '\"">' + relatedPost.title + '</a></li>'
+    })
+  
+    relatedPostsList.innerHTML = relatedPostsString
+  }
 
 }).catch(function(error) {
   console.log(error)


### PR DESCRIPTION
### Background
Previously, our monitoring for the isomer recommender was detecting a lot of 4xx errors. These errors occurred in the lambda function when retrieving recommendations for pages for which the recommendations had not been generated (and so there was an `attempted to read field of undefined` error). This is because recommendations are only generated once a day, and so if a new page was added to the website, it takes several hours before the recommendations are created.

A fix was implemented in the lambda function; we check if the recommendations exist (i.e. if the object is defined) before attempting to read a field in the object. However, the isomer frontend now faces the following bug if there are no recommendations:

<img width="1552" alt="Screenshot 2021-01-05 at 4 20 18 PM" src="https://user-images.githubusercontent.com/19917616/103622600-ec57ae00-4f71-11eb-86c0-83814994007c.png">

The bug is that if there are no recommendations, the isomer frontend still displays the `Related Content` header.

### Fix

This fix checks if there are any recommendations before displaying/unhiding the `Related Content` header.
