### PR TITLE
feat: update files for isomer-jekyll gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,3 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
-gem 'jekyll'
-group :jekyll_plugins do
-	gem "jekyll-feed"
-	gem "jekyll-assets"
-	gem "jekyll-sitemap"
-	gem "jekyll-paginate"
-end
+
+gem "isomer-jekyll", group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -20,10 +20,9 @@ url: "https://www.tech.gov.sg" # the base hostname & protocol for your site, e.g
 plugins:
   - jekyll-feed
   - jekyll-assets
-  # - jekyll-paginate
+  - jekyll-paginate
   - jekyll-sitemap
-  # - jekyll-paginate-v2
-  # - sanitize
+  - jekyll-remote-theme
 safe: false
 exclude:
   [

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,0 @@
-[[headers]]
-  for = "/*"
-  [headers.values]
-    X-Frame-Options = "DENY"
-    X-XSS-Protection = "1; mode=block"
-    Referrer-Policy = "no-referrer"
-    X-Content-Type-Options = "nosniff"


### PR DESCRIPTION
**This PR should be merged only when we migrate to Jekyll 4.**

This PR updates isomerpages-template to include changes introduced by Isomer Jekyll gem [link](https://github.com/opengovsg/isomer-jekyll).

The changes introduced are also added to 
- isomer-tooling [link](https://github.com/isomerpages/isomer-tooling/pull/6)
- isomer-conversion-scripts [link](https://github.com/isomerpages/isomer-conversion-scripts/pull/19)
- isomerpages-template [here]
- site-creation-backend [link](https://github.com/isomerpages/site-creation-backend/pull/160)

Specifically, the changes are:
- modify `netlify.toml` to an empty file
- ~delete `.ruby-version` from repo~ (not in repo)
- ~delete `Gemfile.lock` from repo~ (not in repo)
- modify `Gemfile` to install `isomer-jekyll` gem
- modify `.gitignore` to include `.jekyll-cache` (for Jekyll 4.0)
- modify `_config.yml` to include Isomer Jekyll gem-specific `plugins:`