### PR TITLE
feat: add vica integration to next gen

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -42,6 +42,12 @@
     <link rel="stylesheet" href="{{- site.baseurl -}}/assets/css/blueprint.css">
     <link rel="stylesheet" href="{{- site.baseurl -}}{{- site.custom_css_path -}}">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,600" crossorigin="anonymous">
+    {%- if site.vica -%}
+        <link
+            href="https://webchat.vica.gov.sg/static/css/chat.css"
+            rel="stylesheet"
+        />
+    {%- endif -%}
     {%- feed_meta -%}
 
     {%- include wogaa_scripts.html -%}


### PR DESCRIPTION
## Overview
This PR adds a new `vica` option in the `_config.yml` file which, if true, includes the vica stylesheet as part of the website head.

## Details
The vica chatbot integration requires the insertion of three HTML elements:
1.  a `<script>` referencing the vica chatbot located in the body
2. a `<div>` for specifying the chatbot configuration, which the aforementioned script latches onto
3. a stylesheet located in the head of the website

What this looks like:
```
<head>
    ...
    ...
    <link
        href="https://webchat.vica.gov.sg/static/css/chat.css"
        rel="stylesheet"
    />
</head>
<body>
    ...
    ...
    <div
        id="webchat"
        app-id="<your app id>"
        app-name="<your app name>"
        app-colour="#FFA500"
        app-icon="https://file.go.gov.sg/32h9vk.png" 
        app-subtitle="app-welcome-message"
        app-environment-override="draft" # for staging sites only
    ></div>
    <script
        type="text/javascript" 
        src="https://webchat.vica.gov.sg/static/js/chat.js"
    ></script>
</body>
```

We can include 1. and 2. in the `chatbot-scripts` include which already exist in the template. However, we don't currently have a suitable way of adding to the head of the website. This PR adds a new `site.vica` option which, if true, includes the vica stylesheet as part of the website head.

## To-do
- Update Gitbook documentation with VICA integration instructions (adding `vica: true` to `_config.yml`, and the elements 1. and 2. to the `chatbot-scripts.html` include)