### PR TITLE
chore: add referrerpolicy "origin" for VICA chat.css

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -47,6 +47,7 @@
         <link
             href="https://webchat.vica.gov.sg/static/css/chat.css"
             rel="stylesheet"
+            referrerpolicy="origin"
         />
     {%- endif -%}
     {%- feed_meta -%}


### PR DESCRIPTION
This PR adds the referrer policy `referrerpolicy="origin"` for the VICA chat.css. This was a request by the VICA team and it is good security practice.