### PR TITLE
fix: prevent fields from showing up if blank

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -167,28 +167,28 @@
                             {%- endif -%}
                         {%- endfor -%}
                     {%- endif -%}
-                    {%- if site.data.footer.faq -%}
+                    {%- if site.data.footer.faq and site.data.footer.faq != "" -%}
                         <li>
                             {%- assign url_input = site.data.footer.faq -%}
                             {%- include functions/external_url.html -%}
                             <p><a {{anchor}}>FAQ</a></p>
                         </li>
                     {%- endif -%}
-                    {%- if site.data.footer.contact_us -%}
+                    {%- if site.data.footer.contact_us and site.data.footer.contact_us != "" -%}
                         <li>
                             {%- assign url_input = site.data.footer.contact_us -%}
                             {%- include functions/external_url.html -%}
                             <p><a {{anchor}}>Contact Us</a></p>
                         </li>
                     {%- endif -%}
-                    {%- if site.data.footer.feedback -%}
+                    {%- if site.data.footer.feedback and site.data.footer.feedback != "" -%}
                         <li>
                             {%- assign url_input = site.data.footer.feedback -%}
                             {%- include functions/external_url.html -%}
                             <p><a {{anchor}}>Feedback</a></p>
                         </li>
                     {%- endif -%}
-                    {%- if site.data.footer.show_reach -%}
+                    {%- if site.data.footer.show_reach and site.data.footer.show_reach != "" -%}
                         <li>
                             {%- assign url_input = "https://www.reach.gov.sg/" -%}
                             {%- include functions/external_url.html -%}
@@ -196,7 +196,7 @@
                         </li>
                     {%- endif -%}
                     <li><p><a href="https://www.tech.gov.sg/report_vulnerability/">Report Vulnerability</a></p></li>
-                    {%- if site.data.footer.privacy_policy -%}
+                    {%- if site.data.footer.privacy_policy and site.data.footer.privacy_policy != "" -%}
                         {%- assign url_input = site.data.footer.privacy_policy -%}
                         {%- include functions/external_url.html -%}
                     {%- else -%}
@@ -205,7 +205,7 @@
                     {%- endif -%}
                     <li><p><a {{anchor}}>Privacy Statement</a></p></li>
                     
-                    {%- if site.data.footer.terms_of_use -%}
+                    {%- if site.data.footer.terms_of_use and site.data.footer.terms_of_use != "" -%}
                         {%- assign url_input = site.data.footer.terms_of_use -%}
                         {%- include functions/external_url.html -%}
                     {%- else -%}
@@ -217,14 +217,14 @@
             </div>
             {%- if social -%}
                 <div class="col social-link-container has-text-right-desktop padding--top--sm padding--bottom--sm is-hidden-tablet-only is-hidden-mobile">
-                    {%- if social.facebook -%}
+                    {%- if social.facebook and social.facebook != "" -%}
                         {%- assign url_input = social.facebook -%}
                         {%- include functions/external_url.html -%}
                         <a {{anchor}} class="social-link padding--left padding--bottom is-inline-block">
                             <span class="sgds-icon sgds-icon-facebook is-size-4" title="Facebook"></span>
                         </a>
                     {%- endif -%}
-                    {%- if social.twitter -%}
+                    {%- if social.twitter and social.twitter != "" -%}
                         {%- assign url_input = social.twitter -%}
                         {%- include functions/external_url.html -%}
                         <a {{anchor}} class="social-link padding--left padding--bottom is-inline-block">
@@ -238,28 +238,28 @@
                             <span class="sgds-icon sgds-icon-youtube is-size-4" title="YouTube"></span>
                         </a>
                     {%- endif -%}
-                    {%- if social.instagram -%}
+                    {%- if social.instagram and social.instagram != "" -%}
                         {%- assign url_input = social.instagram -%}
                         {%- include functions/external_url.html -%}
                         <a {{anchor}} class="social-link padding--left padding--bottom is-inline-block">
                             <span class="bx bxl-instagram-alt is-size-4" title="Instagram"></span>
                         </a>
                     {%- endif -%}
-                    {%- if social.linkedin -%}
+                    {%- if social.linkedin and social.linkedin != "" -%}
                         {%- assign url_input = social.linkedin -%}
                         {%- include functions/external_url.html -%}
                         <a {{anchor}} class="social-link padding--left padding--bottom is-inline-block">
                             <span class="sgds-icon sgds-icon-linkedin is-size-4" title="LinkedIn"></span>
                         </a>
                     {%- endif -%}
-                    {%- if social.telegram -%}
+                    {%- if social.telegram and social.telegram != "" -%}
                         {%- assign url_input = social.telegram -%}
                         {%- include functions/external_url.html -%}
                         <a {{anchor}} class="social-link padding--left padding--bottom is-inline-block">
                             <span class='bx bxl-telegram' style="font-size:24px" title="Telegram"></span>
                         </a>
                     {%- endif -%}
-                    {%- if social.tiktok -%}
+                    {%- if social.tiktok and social.tiktok != "" -%}
                         {%- assign url_input = social.tiktok -%}
                         {%- include functions/external_url.html -%}
                         <a {{anchor}} class="social-link padding--left padding--bottom is-inline-block">
@@ -330,28 +330,28 @@
                             {%- endif -%}
                         {%- endfor -%}
                     {%- endif -%}
-                    {%- if site.data.footer.faq -%}
+                    {%- if site.data.footer.faq and site.data.footer.faq != "" -%}
                             {%- assign url_input = site.data.footer.faq -%}
                             {%- include functions/external_url.html -%}
                             <p><a {{anchor}}>FAQ</a></p>
                     {%- endif -%}
-                    {%- if site.data.footer.contact_us -%}
+                    {%- if site.data.footer.contact_us and site.data.footer.contact_us != "" -%}
                             {%- assign url_input = site.data.footer.contact_us -%}
                             {%- include functions/external_url.html -%}
                             <p><a {{anchor}}>Contact Us</a></p>
                     {%- endif -%}
-                    {%- if site.data.footer.feedback -%}
+                    {%- if site.data.footer.feedback and site.data.footer.feedback != "" -%}
                             {%- assign url_input = site.data.footer.feedback -%}
                             {%- include functions/external_url.html -%}
                             <p><a {{anchor}}>Feedback</a></p>
                     {%- endif -%}
-                    {%- if site.data.footer.show_reach -%}
+                    {%- if site.data.footer.show_reach and site.data.footer.show_reach != "" -%}
                             {%- assign url_input = "https://www.reach.gov.sg/" -%}
                             {%- include functions/external_url.html -%}
                             <p><a {{anchor}} title="Link to reach.gov.sg">REACH</a></p>
                     {%- endif -%}
                     <p><a href="https://www.tech.gov.sg/report_vulnerability/">Report Vulnerability</a></p>
-                    {%- if site.data.footer.privacy_policy -%}
+                    {%- if site.data.footer.privacy_policy and site.data.footer.privacy_policy != "" -%}
                         {%- assign url_input = site.data.footer.privacy_policy -%}
                         {%- include functions/external_url.html -%}
                     {%- else -%}
@@ -360,7 +360,7 @@
                     {%- endif -%}
                     <p><a {{anchor}}>Privacy Statement</a></p>
                     
-                    {%- if site.data.footer.terms_of_use -%}
+                    {%- if site.data.footer.terms_of_use and site.data.footer.terms_of_use != "" -%}
                         {%- assign url_input = site.data.footer.terms_of_use -%}
                         {%- include functions/external_url.html -%}
                     {%- else -%}
@@ -372,7 +372,7 @@
         </div>
         <div class="row">
             <div class="col social-link-container is-hidden-desktop padding--top--lg padding--bottom--none">
-                {%- if social.facebook -%}
+                {%- if social.facebook and social.facebook != "" -%}
                     {%- assign url_input = social.facebook -%}
                     {%- include functions/external_url.html -%}
                     <a {{anchor}} class="social-link padding--right" title="Facebook">
@@ -380,7 +380,7 @@
                     </a>
                 {%- endif -%}
 
-                {%- if social.twitter -%}
+                {%- if social.twitter and social.twitter != "" -%}
                     {%- assign url_input = social.twitter -%}
                     {%- include functions/external_url.html -%}
                     <a {{anchor}} class="social-link padding--right" title="Twitter">
@@ -388,7 +388,7 @@
                     </a>
                 {%- endif -%}
 
-                {%- if social.youtube -%}
+                {%- if social.youtube and social.youtube != "" -%}
                     {%- assign url_input = social.youtube -%}
                     {%- include functions/external_url.html -%}
                     <a {{anchor}} class="social-link padding--right" title="YouTube">
@@ -396,7 +396,7 @@
                     </a>
                 {%- endif -%}
 
-                {%- if social.instagram -%}
+                {%- if social.instagram and social.instagram != "" -%}
                     {%- assign url_input = social.instagram -%}
                     {%- include functions/external_url.html -%}
                     <a {{anchor}} class="social-link padding--right" title="Instagram">
@@ -404,7 +404,7 @@
                     </a>
                 {%- endif -%}
 
-                {%- if social.linkedin -%}
+                {%- if social.linkedin and social.linkedin != "" -%}
                     {%- assign url_input = social.linkedin -%}
                     {%- include functions/external_url.html -%}
                     <a {{anchor}} class="social-link padding--right" title="LinkedIn">
@@ -412,7 +412,7 @@
                     </a>
                 {%- endif -%}
 
-                {%- if social.telegram -%}
+                {%- if social.telegram and social.telegram != "" -%}
                     {%- assign url_input = social.telegram -%}
                     {%- include functions/external_url.html -%}
                     <a {{anchor}} class="social-link padding--right">
@@ -420,7 +420,7 @@
                     </a>
                 {%- endif -%}
 
-                {%- if social.tiktok -%}
+                {%- if social.tiktok and social.tiktok != "" -%}
                     {%- assign url_input = social.tiktok -%}
                     {%- include functions/external_url.html -%}
                     <a {{anchor}} class="social-link padding--right">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -53,15 +53,15 @@
     {%- feed_meta -%}
 
     {%- include wogaa_scripts.html -%}
-    {%- if site.facebook-pixel -%}
+    {%- if site.facebook-pixel and site.facebook-pixel != "" -%}
         <script src="{{- "assets/js/facebook-pixel.js" | relative_url -}}" crossorigin="anonymous"></script>
         <noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id={{- site.facebook-pixel -}}&ev=PageView&noscript=1"/></noscript>
     {%- endif -%}
-    {%- if site.linkedin-insights -%}
+    {%- if site.linkedin-insights and site.linkedin-insights != "" -%}
         <script src="{{- "assets/js/linkedin-insights.js" | relative_url -}}" crossorigin="anonymous"></script>
         <noscript><img height="1" width="1" style="display:none" src="https://px.ads.linkedin.com/collect/?pid={{- site.linkedin-insights -}}&fmt=gif" /></noscript>
     {%- endif -%}
-    {%- if site.google-tag-manager -%}
+    {%- if site.google-tag-manager and site.google-tag-manager != "" -%}
         <script src="{{- "assets/js/google-tag-manager.js" | relative_url -}}" crossorigin="anonymous"></script>
     {%- endif -%}
     <title>

--- a/_layouts/contact_us.html
+++ b/_layouts/contact_us.html
@@ -38,8 +38,8 @@ layout: skeleton
             <div class="col is-8 is-offset-2">
                 {%- for location in page.locations -%}
                     <div class="row is-multiline margin--bottom">
-                        {%- if location.address -%}
-                            {%- if location.title -%}
+                        {%- if location.address and location.address != "" -%}
+                            {%- if location.title and location.title != "" -%}
                                 <div class="col is-6 padding--bottom--none">
                                     {%- comment -%}<p></p>{%- endcomment -%}
                                     <h5 class="has-text-secondary"><b>{{- location.title -}}</b></h5>
@@ -48,7 +48,7 @@ layout: skeleton
 
                             
                             <div class="col is-6 padding--bottom--none is-hidden-mobile">
-                                {%- if location.operating_hours -%}
+                                {%- if location.operating_hours and location.operating_hours.size != 0 -%}
                                     <h5 class="has-text-secondary"><b>Operating Hours</b></h5>
                                 {%- endif -%}
                             </div>
@@ -59,7 +59,7 @@ layout: skeleton
                                     <h5 class="has-text-secondary"><b>Other Offices</b></h5>
                                 </div>
                                 <div class="col is-6 padding--bottom--none">
-                                    {%- if location.operating-hours -%}
+                                    {%- if location.operating-hours and location.operating_hours.size != 0 -%}
                                     <h5 class="has-text-secondary"><b>Operating Hours</b></h5>
                                     {%- endif -%}
                             </div>
@@ -71,7 +71,7 @@ layout: skeleton
                                         {{- location.address | join: "</p><p class='content margin--top--none margin--bottom--none'>" -}}
                                     </p>
 
-                                    {%- if location.maps_link -%}
+                                    {%- if location.maps_link and location.maps_link != "" -%}
                                         {%- assign url_input = location.maps_link -%}
                                         {%- include functions/external_url.html -%}
                                     {%- else -%}
@@ -87,7 +87,7 @@ layout: skeleton
                                     </a>
                                 </div>
                             </div>
-                            {%- if location.operating_hours -%}
+                            {%- if location.operating_hours and location.operating_hours != "" -%}
                                 <div class="col is-6">
                                     {%- assign operating_hours = location.operating_hours -%}
                                     <div>
@@ -104,28 +104,28 @@ layout: skeleton
                     </div>
                 {%- endfor -%}
 
-                {%- if page.contacts -%}
+                {%- if page.contacts and page.contacts != "" -%}
                     <div class="row is-multiline margin--bottom--xl">
                         <div class="col is-12 padding--bottom--none">
                             <h5 class="has-text-secondary"><b>Contact Us</b></h5>
                         </div>
                         {%- for contact in page.contacts -%}
-                            {%- if contact.content -%}
+                            {%- if contact.content and contact.content != "" -%}
                                 <div class="col is-6">
                                     <div>
-                                        {%- if contact.title -%}
+                                        {%- if contact.title and contact.title != "" -%}
                                             <p class="has-text-weight-semibold margin--top--none margin--bottom--none">{{contact.title}}</p>
                                         {%- endif -%}
 
                                         {%- for content in contact.content -%}
                                             <p class="margin--top--none margin--bottom--none">
-                                                {%- if content.email -%}
+                                                {%- if content.email and content.email != "" -%}
                                                     <a href="mailto:{{content.email | strip -}}">
                                                         <u>{{- content.email | strip -}}</u>
                                                     </a>
                                                 {%- endif -%}
 
-                                                {%- if content.phone -%}
+                                                {%- if content.phone and content.phone != "" -%}
                                                     <a href="tel:{{content.phone | normalize_whitespace | replace: " ", "" -}}">
                                                         <u>{{- content.phone | strip -}}</u>
                                                     </a>
@@ -143,7 +143,7 @@ layout: skeleton
                     </div>
                 {%- endif -%}
 
-                {%- if site.data.footer.feedback -%}
+                {%- if site.data.footer.feedback and site.data.footer.feedback != "" -%}
                     <div class="row is-multiline margin--bottom--lg">
                         <div class="col is-12 padding--bottom--none">
                             <h5 class="has-text-secondary has-text-weight-semibold">Send us your feedback</h5>

--- a/assets/js/google_analytics.js
+++ b/assets/js/google_analytics.js
@@ -13,7 +13,7 @@ ga('t1.require', 'outboundLinkTracker', {
     events: ['click', 'auxclick', 'contextmenu']
 });
 
-{%- if site.google_analytics -%}
+{%- if site.google_analytics and site.google_analytics != "" -%}
     ga('create', '{{site.google_analytics}}', 'auto', 't2');
 
     ga('t2.require', 'pageVisibilityTracker', {


### PR DESCRIPTION
This PR adds additional checks to prevent the rendering of fields in the footer and contact us pages if they are blank. It also checks for empty analytics fields (`google_analytics`, `linkedin-insights`, `facebook-pixel`).

Note: this change is only made on sites on next-gen(isomer v2 and above), since v1 repos are unlikely to leave these fields empty instead of deleting them.