### PR TITLE
Fix: sizes for footer links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -75,7 +75,7 @@
                         </div>
                     {%- elsif navlink.sublinks -%}
                         {%- comment -%} Leftnav page with custom sublinks {%- endcomment -%}
-                        <div class="col is-one-fifth is-hidden-tablet-only is-hidden-mobile padding--bottom--lg is-left">
+                        <div class="col footer-page-links is-one-fifth is-hidden-tablet-only is-hidden-mobile padding--bottom--lg is-left">
                             {%- assign url_input = navlink.url -%}
                             {%- include functions/external_url.html -%}
                             
@@ -97,7 +97,7 @@
                             {%- endfor -%}
                         </div>
                     {%- elsif navlink.resource_room -%}
-                        <div class="col is-one-fifth is-hidden-tablet-only is-hidden-mobile padding--bottom--lg is-left">
+                        <div class="col footer-page-links is-one-fifth is-hidden-tablet-only is-hidden-mobile padding--bottom--lg is-left">
                             <p class="sub-header">
                                 <b><a class="has-text-white" href="/{{site.resources_name}}/">
                                     {{- navlink.title -}}
@@ -138,7 +138,7 @@
                     {%- else -%}
                         {%- comment -%} Single page {%- endcomment -%}
                         
-                        <div class="col is-one-fifth is-hidden-tablet-only is-hidden-mobile padding--bottom--lg is-left">
+                        <div class="col footer-page-links is-one-fifth is-hidden-tablet-only is-hidden-mobile padding--bottom--lg is-left">
                             {%- assign url_input = navlink.url -%}
                             {%- include functions/external_url.html -%}
                             


### PR DESCRIPTION
This PR fixes an inconsistency in the size of some footer links - this was caused due to us not correctly setting the classname for certain types of footer links.

Before:
<img width="1451" alt="Screenshot 2022-08-25 at 1 31 26 PM" src="https://user-images.githubusercontent.com/22111124/186582621-b806706b-9779-48d6-8832-fb89ec02a9be.png">


After:
<img width="1394" alt="Screenshot 2022-08-25 at 1 36 03 PM" src="https://user-images.githubusercontent.com/22111124/186583235-d4fb6f5e-84f1-4818-97eb-ee6385ef692c.png">
 