### PR TITLE
Feat: remove extra page sidebar icons

### DIFF
--- a/_includes/print.html
+++ b/_includes/print.html
@@ -16,37 +16,6 @@
             <input id="page-url" type="text" class="hide" value="{{page.url|absolute_url}}">
             {%- comment -%} The only cross-browser compatible way to copy the current page url into a clipboard is to store it in a hidden input box {%- endcomment -%}
         </div>
-        <div class="actionbar__inner padding--top--sm">
-            <a href="mailto:?Subject={{page.title}}&amp;Body= {{page.url|absolute_url}}" id="mail-anchor" aria-label="Mail">
-            <button class="bp-button">
-            <i 
-              class="sgds-icon sgds-icon-mail is-size-4">
-            </i>
-            </button>
-            </a>
-        </div>
-        <div class="actionbar__inner padding--top--sm">
-            {%- assign url_input = "http://www.facebook.com/sharer.php?u={{page.url|absolute_url|escape}}"" -%}
-            {%- include functions/external_url.html -%}
-            <a {{anchor}} id="fb-anchor" aria-label="Share in Facebook">
-            <button class="bp-button">
-              <i 
-              class="sgds-icon sgds-icon-facebook-alt is-size-4">
-              </i>
-            </button>
-            </a>
-        </div>
-        <div class="actionbar__inner padding--top--sm">
-            {%- assign url_input = "https://www.linkedin.com/sharing/share-offsite/?url={{page.url|absolute_url|escape}}&title={{page.title}}"" -%}
-            {%- include functions/external_url.html -%}
-            <a {{anchor}} id="li-anchor" aria-label="Share in LinkedIn">
-            <button class="bp-button">
-              <i 
-              class="sgds-icon sgds-icon-linkedin-alt is-size-4">
-              </i>
-            </button>
-            </a>
-        </div>
     </div>
 </div>
 


### PR DESCRIPTION
Setting as draft - we haven't done the user interviews to determine if this is a significant issue and this is relatively low impact

---

This PR removes the sidebar icons (email, facebook, linkedin) from all pages, as agencies were providing feedback that sharing pages through these means were not useful and providing confusion to users.
