### PR TITLE
Feat: add icon on resource cards for external link

### DIFF
--- a/_layouts/resources-alt.html
+++ b/_layouts/resources-alt.html
@@ -85,6 +85,10 @@ layout: skeleton
                                 <small class="has-text-white">  
                                     <span class="sgds-icon sgds-icon-download align-right is-size-4"></span>
                                 </small>
+                            {%- elsif post.layout == 'link' -%}
+                                <small class="has-text-white">
+                                    <span class="bx bx-link-external align-right is-size-4"></span>
+                                </small>
                             {%- endif -%}
                         </div>
                     </div>

--- a/_layouts/resources.html
+++ b/_layouts/resources.html
@@ -71,6 +71,10 @@ layout: skeleton
                                     <small class="has-text-white">
                                         <span class="sgds-icon sgds-icon-download align-right is-size-4"></span>
                                     </small>
+                                {%- elsif post.layout == 'link' -%}
+                                    <small class="has-text-white">
+                                        <span class="bx bx-link-external align-right is-size-4"></span>
+                                    </small>
                                 {%- endif -%}
                             </div>
                         </div>

--- a/resource_room/resource-room-stuff/_posts/2022-09-15-link-external.md
+++ b/resource_room/resource-room-stuff/_posts/2022-09-15-link-external.md
@@ -1,0 +1,6 @@
+---
+title: "External link to Google"
+date: 2022-09-15
+permalink: "https://www.google.com"
+layout: link
+---


### PR DESCRIPTION
This PR adds an additional icon to a newly introduced new layout type for resource pages (`link`). To be reviewed in conjunction with PR #[1064](https://github.com/isomerpages/isomercms-frontend/pull/1064) on the isomercms-frontend repo and PR #[500](https://github.com/isomerpages/isomercms-backend/pull/500) on the isomercms-backend repo.

Note that this change will not be replicated on the pre-cms template - the formatting is specific to files on the cms and there would be little benefit to also introduce it to existing v1/v2 sites.