### PR TITLE
fix(datagovsg-search): sanitize value with DOMPurify

### DIFF
--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -102,7 +102,7 @@ function displayTable(chunk, fields) {
   }
   resultString += '</table></div>';
 
-  document.getElementsByClassName("content")[0].innerHTML = resultString;
+  document.getElementsByClassName("content")[0].innerHTML = DOMPurify.sanitize(resultString);
   document.getElementsByClassName("content")[0].style.display = 'block';
 }
 


### PR DESCRIPTION
Ensure that values received from data.gov.sg are sanitized with DOMPurify before set as `innerHTML`