### PR TITLE
Update homepage resources to use permalink

### DIFF
--- a/_includes/homepage/resources.html
+++ b/_includes/homepage/resources.html
@@ -51,7 +51,7 @@
                     </div>
                     {%- else -%}
                         {%- if post.permalink -%}
-                            <a href="{{- post.url -}}" class="is-media-card">
+                            <a href="{{- post.permalink -}}" class="is-media-card">
                         {%- else -%}
                             <a href="{{- post.file_url | relative_url -}}" class="is-media-card" target="_blank" rel="noreferrer">
                         {%- endif -%}


### PR DESCRIPTION
The current homepage resources uses the normal `url`, which is a relative path as defined in the [Jekyll docs](https://jekyllrb.com/docs/variables/) (under `page.url`). This causes external links to become relative URLs and cause issues.

This PR changes that to the `permalink` so that both external and internal links work.