### PR TITLE
feat: add IG embed to pages

### DIFF
--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -57,7 +57,7 @@
 <script src="https://printjs-4de6.kxcdn.com/print.min.js" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/floating-buttons.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/left-nav-interaction.js" | relative_url -}}" crossorigin="anonymous"></script>
-<script async src="https://www.instagram.com/embed.js" crossorigin="anonymous"></script>
+<script src="https://www.instagram.com/static/bundles/es6/EmbedSDK.js/ab12745d93c5.js" integrity="sha384-uCmurhfuSbKidtlFxpgv2j4yIWVfYbrJaFrj62TR3NpFp+msiMilcvgz0gsDY2Yj" crossorigin="anonymous"></script>
   {%- if site.recommender == true -%}
   <script src="{{- "/assets/js/recommender.js" | relative_url -}}" crossorigin="anonymous"></script>
   {%- endif -%}

--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -57,6 +57,7 @@
 <script src="https://printjs-4de6.kxcdn.com/print.min.js" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/floating-buttons.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/left-nav-interaction.js" | relative_url -}}" crossorigin="anonymous"></script>
+<script async src="https://www.instagram.com/embed.js" crossorigin="anonymous"></script>
   {%- if site.recommender == true -%}
   <script src="{{- "/assets/js/recommender.js" | relative_url -}}" crossorigin="anonymous"></script>
   {%- endif -%}


### PR DESCRIPTION
This PR adds the Instagram embed.js code into all Jekyll pages with the page, or post, or similar layouts (i.e. non-homepage/resource room).