### PR TITLE
Fix: handle external links with new front matter

### DIFF
--- a/_layouts/resources-alt.html
+++ b/_layouts/resources-alt.html
@@ -69,10 +69,12 @@ layout: skeleton
                 </div> {%- endcomment -%}
                 {%- elsif post.categories[1] == page_category -%}
                 <div class="col is-one-quarter-widescreen is-one-third-desktop is-half-tablet resource-card-element hide" id="{{- post.date | date: "%Y" -}}">
-                    {%- if post.permalink -%}
-                        <a href="{{- post.permalink | relative_url -}}" class="is-media-card">
-                    {%- else -%}
+                    {%- if post.external -%}
+                        <a href="{{- post.external | relative_url -}}" class="is-media-card" target="_blank">
+                    {%- elsif post.file_url -%}
                         <a href="{{- post.file_url | relative_url -}}" class="is-media-card" target="_blank">
+                    {%- else -%}
+                        <a href="{{- post.permalink | relative_url -}}" class="is-media-card">
                     {%- endif -%}
                     <div class="media-card-plain bg-media-color-{{category_index}} padding--lg">
                         <div>

--- a/_layouts/resources.html
+++ b/_layouts/resources.html
@@ -55,10 +55,12 @@ layout: skeleton
                     {%- endfor -%}
 
                     <div class="col is-one-quarter-widescreen is-one-third-desktop is-half-tablet resource-card-element hide" id="{{- post.date | date: "%Y"}}">
-                        {%- if post.permalink -%}
-                            <a href="{{- post.permalink | relative_url -}}" class="is-media-card">
-                        {%- else -%}
+                        {%- if post.external -%}
+                            <a href="{{- post.external | relative_url -}}" class="is-media-card" target="_blank">
+                        {%- elsif post.file_url -%}
                             <a href="{{- post.file_url | relative_url -}}" class="is-media-card" target="_blank">
+                        {%- else -%}
+                            <a href="{{- post.permalink | relative_url -}}" class="is-media-card">
                         {%- endif -%}
                         <div class="media-card-plain bg-media-color-{{category_index}} padding--lg">
                             <div>

--- a/resource_room/resource-room-stuff/_posts/2022-09-15-link-external.md
+++ b/resource_room/resource-room-stuff/_posts/2022-09-15-link-external.md
@@ -1,6 +1,6 @@
 ---
 title: "External link to Google"
 date: 2022-09-15
-permalink: "https://www.google.com"
+external: "https://www.google.com"
 layout: link
 ---


### PR DESCRIPTION
This PR modifies resource pages of type 'link' to utilise `external` to create links, rather than `permalink`, which is a keyword in jekyll, as this was causing certain urls (those with `?` or `#`) to cause builds to fail.