### PR TITLE
Feat ga4

### DIFF
--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -70,6 +70,6 @@
 <script async src="https://www.google-analytics.com/analytics.js"></script>
 <script async src="{{- site.baseurl -}}/assets/js/autotrack.js"></script>
 
-{%- comment -%} Isomer's Google Tag (used for Google Analytics){%- endcomment -%}
+{%- comment -%} Isomer's Google Tag (GA4) {%- endcomment -%}
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-3RT85MXN6L"></script>
 <script src="{{- site.baseurl -}}/assets/js/google-tag.js"></script>

--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -65,7 +65,7 @@
 
 {%- include chatbot-scripts.html -%}
 
-{%- comment -%} Google Analytics {%- endcomment -%}
+{%- comment -%} Google Analytics (UA) {%- endcomment -%}
 <script src="{{- site.baseurl -}}/assets/js/google_analytics.js"></script>
 <script async src="https://www.google-analytics.com/analytics.js"></script>
 <script async src="{{- site.baseurl -}}/assets/js/autotrack.js"></script>

--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -69,3 +69,7 @@
 <script src="{{- site.baseurl -}}/assets/js/google_analytics.js"></script>
 <script async src="https://www.google-analytics.com/analytics.js"></script>
 <script async src="{{- site.baseurl -}}/assets/js/autotrack.js"></script>
+
+{%- comment -%} Isomer's Google Tag (used for Google Analytics){%- endcomment -%}
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-25BGPGZD1C"></script>
+<script src="{{- site.baseurl -}}/assets/js/google-tag.js"></script>

--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -71,5 +71,5 @@
 <script async src="{{- site.baseurl -}}/assets/js/autotrack.js"></script>
 
 {%- comment -%} Isomer's Google Tag (used for Google Analytics){%- endcomment -%}
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-25BGPGZD1C"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-3RT85MXN6L"></script>
 <script src="{{- site.baseurl -}}/assets/js/google-tag.js"></script>

--- a/assets/js/google-tag.js
+++ b/assets/js/google-tag.js
@@ -11,5 +11,5 @@ gtag('config', 'G-25BGPGZD1C');
 
 // Set site specific ga tag
 if ('{{site.google_analytics_ga4}}' && '{{site.google_analytics_ga4}}' != "") {
-  gtag('config', '{{site.google_analytics2}}');
+  gtag('config', '{{site.google_analytics_ga4}}');
 }

--- a/assets/js/google-tag.js
+++ b/assets/js/google-tag.js
@@ -7,7 +7,7 @@ function gtag(){window.dataLayer.push(arguments);}
 gtag('js', new Date());
 
 // Set Isomer's ga tag
-gtag('config', 'G-25BGPGZD1C');
+gtag('config', 'G-3RT85MXN6L');
 
 // Set site specific ga tag
 if ('{{site.google_analytics_ga4}}' && '{{site.google_analytics_ga4}}' != "") {

--- a/assets/js/google-tag.js
+++ b/assets/js/google-tag.js
@@ -2,6 +2,8 @@
 layout: blank
 ---
 
+// We use layout:blank to make use of jekyll config params
+// Imported script so it isn't blocked by our CSP
 window.dataLayer = window.dataLayer || [];
 function gtag(){window.dataLayer.push(arguments);}
 gtag('js', new Date());

--- a/assets/js/google-tag.js
+++ b/assets/js/google-tag.js
@@ -1,0 +1,15 @@
+---
+layout: blank
+---
+
+window.dataLayer = window.dataLayer || [];
+function gtag(){window.dataLayer.push(arguments);}
+gtag('js', new Date());
+
+// Set Isomer's ga tag
+gtag('config', 'G-25BGPGZD1C');
+
+// Set site specific ga tag
+if ('{{site.google_analytics_ga4}}' && '{{site.google_analytics_ga4}}' != "") {
+  gtag('config', '{{site.google_analytics2}}');
+}


### PR DESCRIPTION
This PR introduces Google tag for use for agencies to swap over from UA to GA4, as well as to swap Isomer's site tracking data to GA4. We will continue to maintain the UA compatibility until closer to the sunsetting date, so that agencies have time to gather data on the new GA4 tag. The corresponding change to allow agencies to modify this on the CMS will be made in a future PR.

For testing:
The repo [a-test-v4](https://github.com/isomerpages/a-test-v4) has been set up to use this version of the template. The main things tested are
- Whether site visits are logged to both the general isomer sites GA tracker as well as the site specific tracker (denoted by `google_analytics_ga4` in the `config.yml` file of the repo)
- Site visits to sites with no `google_analytics_ga4` param should still track visits with the general isomer tag
- Events to UA are still being triggered

The data on information being sent to the respective tags can be inspected using [Google tag assistant](https://tagassistant.google.com/)