### PR TITLE
Feat/Google Tag Manager

### DIFF
--- a/_includes/google-tag-manager.html
+++ b/_includes/google-tag-manager.html
@@ -1,0 +1,6 @@
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-TQ8G2P9');
+</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,12 @@
 <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-TQ8G2P9');
+    </script>
+    <!-- End Google Tag Manager -->
     <meta charset="utf8">
     <meta name="viewport"
           content="width=device-width, user-scalable=yes, initial-scale=1.0">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,12 +1,5 @@
 <head>
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','GTM-TQ8G2P9');
-    </script>
-    <!-- End Google Tag Manager -->
+    {%- include google-tag-manager.html -%}
     <meta charset="utf8">
     <meta name="viewport"
           content="width=device-width, user-scalable=yes, initial-scale=1.0">

--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -73,3 +73,7 @@
 {%- comment -%} Isomer's Google Tag (GA4) {%- endcomment -%}
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-3RT85MXN6L"></script>
 <script src="{{- site.baseurl -}}/assets/js/google-tag.js"></script>
+
+{%- comment -%} Isomer's Google Tag Manager {%- endcomment -%}
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TQ8G2P9"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/assets/js/google-tag.js
+++ b/assets/js/google-tag.js
@@ -4,8 +4,30 @@ layout: blank
 
 // We use layout:blank to make use of jekyll config params
 // Imported script so it isn't blocked by our CSP
+const perfObserver = new PerformanceObserver((observedEntries) => {
+  const entry =
+    observedEntries.getEntriesByType('navigation')[0]
+  console.log('pageload time: ', entry.duration)
+  // window.dataLayer.push({ pageLoadTime: 5 })
+  // if (entry.duration === 0) return
+  const parsedLoadTime = Math.round(entry.duration / 100) / 10;
+  console.log(parsedLoadTime)
+  window.dataLayer.push({ 
+    event: 'performance',
+    entryType: entry.entryType,
+    pageLoadTime: Math.round(entry.duration / 100) / 10, 
+  })
+})
+
+perfObserver.observe({
+  type: 'navigation',
+  buffered: true
+})
+
 window.dataLayer = window.dataLayer || [];
-function gtag(){window.dataLayer.push(arguments);}
+function gtag(){
+  window.dataLayer.push(arguments);
+}
 gtag('js', new Date());
 
 // Set Isomer's ga tag

--- a/assets/js/google-tag.js
+++ b/assets/js/google-tag.js
@@ -7,11 +7,6 @@ layout: blank
 const perfObserver = new PerformanceObserver((observedEntries) => {
   const entry =
     observedEntries.getEntriesByType('navigation')[0]
-  console.log('pageload time: ', entry.duration)
-  // window.dataLayer.push({ pageLoadTime: 5 })
-  // if (entry.duration === 0) return
-  const parsedLoadTime = Math.round(entry.duration / 100) / 10;
-  console.log(parsedLoadTime)
   window.dataLayer.push({ 
     event: 'performance',
     entryType: entry.entryType,


### PR DESCRIPTION
This PR adds Google Tag Manager to all Isomer sites, in order to facilitate the addition of site load time metric tracking.

For the implementation of Google Tag Manager, we need to add separate code snippets in both the `<head>` and `<body>` components. What complicates matters is the portion in the `<head>` needs to run an inline script, which is blocked by our csp - unlike the GA4 implementation, this cannot be worked around by using `layout:blank` to simulate a jekyll page, as that only works for content in the body. Instead, what we're doing here is to allow the hash of this inline script in our CSP - the PR [#38](https://github.com/opengovsg/isomer-build/pull/38) and [#39](https://github.com/opengovsg/isomer-build/pull/39) on the isomer-build repo should be reviewed in conjunction with this PR.

Currently, we can verify that this works via [Google Tag Assistant](https://tagassistant.google.com/), which allows us to inspect the events being fired off on sites. The changes from this PR have been added to https://a-test-v4-staging.netlify.app/, and inspecting the events fired when accessing the page should correctly show the page_load_time event firing with the correct time metric. Unfortunately, it doesn't seem to show up on the Google Analytics dashboard currently - I suspect this is an issue with data sampling which prevents results from showing up properly if there are an insufficient number of events. As discussed offline with Kishore, we suspect that enabling this for all sites would provide us with enough data to get it to show up, and this change should not affect user site performance in any way, thus we're okay with releasing this first.

The performance metric being measured is navigation timing, which represents the time from when the user navigated to a new page until the load event of the page is complete. It includes network latency, DNS resolution, server response time, and the time taken for the browser to process and render the page. [link](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/duration)

Resolves IS-127.