### PR TITLE
refactor(hero): change gray overlay to not be present on image

### DIFF
--- a/_includes/homepage/hero.html
+++ b/_includes/homepage/hero.html
@@ -13,7 +13,6 @@
   <div class="bp-hero-body gray-overlay">
     <div class="bp-container margin--top--lg">
       <div class="row is-vcentered is-centered ma">
-        {%- if section.hero.variant != 'image' -%}
         <div class="col is-9 has-text-centered has-text-white">
           <h1 class="display padding--bottom--lg margin--none">
             <b class="is-hidden-touch">{{- section.hero.title -}}</b>
@@ -79,7 +78,6 @@
           </a>
           {%- endif -%} {%- endif -%}
         </div>
-        {%- endif -%}
       </div>
     </div>
   </div>

--- a/_includes/homepage/hero.html
+++ b/_includes/homepage/hero.html
@@ -9,7 +9,8 @@
 </style>
 
 <section class="bp-hero bg-hero">
-  <div class="bp-hero-body">
+  {%- if section.hero.variant != 'image' -%}
+  <div class="bp-hero-body gray-overlay">
     <div class="bp-container margin--top--lg">
       <div class="row is-vcentered is-centered ma">
         {%- if section.hero.variant != 'image' -%}
@@ -78,12 +79,19 @@
           </a>
           {%- endif -%} {%- endif -%}
         </div>
-        {%- endif -%} {%- if section.hero.variant == 'image' -%}
-        <div class="min-height-mobile" />
         {%- endif -%}
       </div>
     </div>
   </div>
+  {%- endif -%} {%- if section.hero.variant == 'image' -%}
+  <div class="bp-hero-body">
+    <div class="bp-container margin--top--lg">
+      <div class="row is-vcentered is-centered ma">
+        <div class="min-height-mobile" />
+      </div>
+    </div>
+  </div>
+  {%- endif -%}
 </section>
 
 {%- if section.hero.key_highlights -%}

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -9160,7 +9160,6 @@ a.navbar-link.is-active {
   flex-shrink: 0;
 }
 .bp-hero-body {
-  background: rgba(0, 0, 0, 0.25);
   flex-grow: 1;
   flex-shrink: 0;
   padding: 3rem 1.5rem;

--- a/assets/css/components/hero.css
+++ b/assets/css/components/hero.css
@@ -1,3 +1,7 @@
 .min-height-mobile {
   min-height: 398px;
 }
+
+.gray-overlay {
+  background: rgba(0, 0, 0, 0.25);
+}


### PR DESCRIPTION
## Problem
previously, image only variant had gray overlay

## Solution 
- add gray overlay as own css class
- add it to original hero body