### PR TITLE
feat(hero-dropdown): extract to component + use

### DIFF
--- a/_includes/homepage/hero.html
+++ b/_includes/homepage/hero.html
@@ -32,54 +32,9 @@
           <p class="is-hidden-mobile padding--bottom--lg">
             {{- section.hero.subtitle -}}
           </p>
-          {%- endif -%} {%- if section.hero.dropdown -%}
-          <div class="bp-dropdown margin--top--sm">
-            <div class="bp-dropdown-trigger">
-              <a
-                class="bp-button bp-dropdown-button hero-dropdown is-centered"
-                aria-haspopup="true"
-                aria-controls="hero-dropdown-menu"
-              >
-                {%- if section.hero.dropdown.title -%}
-                <span>
-                  <b>
-                    <p>{{- section.hero.dropdown.title -}}</p>
-                  </b>
-                </span>
-                {%- else -%}
-                <span>
-                  <b>
-                    <p>I want to...</p>
-                  </b>
-                </span>
-                {%- endif -%}
-                <span class="icon is-small">
-                  <i
-                    class="sgds-icon sgds-icon-chevron-down is-size-4"
-                    aria-hidden="true"
-                  ></i>
-                </span>
-              </a>
-            </div>
-            <div
-              class="bp-dropdown-menu has-text-left"
-              id="hero-dropdown-menu"
-              role="menu"
-            >
-              <div class="bp-dropdown-content is-centered">
-                {%- for option in section.hero.dropdown.options -%} {%- if
-                option.url and option.title -%}
-                <a
-                  class="bp-dropdown-item"
-                  href="{{- site.baseurl -}}{{ option.url }}"
-                >
-                  <h5>{{ option.title }}</h5>
-                </a>
-                {%- endif -%} {%- endfor -%}
-              </div>
-            </div>
-          </div>
-          {%- else -%} {%- if section.hero.url and section.hero.button -%}
+          {%- endif -%} {%- if section.hero.dropdown -%} {% include
+          homepage/hero/components/hero-dropdown.html %} {%- else -%} {%- if
+          section.hero.url and section.hero.button -%}
           <a
             href="{{- site.baseurl -}}{{- section.hero.url -}}"
             class="bp-button is-secondary is-uppercase search-button"

--- a/_includes/homepage/hero/components/hero-dropdown.html
+++ b/_includes/homepage/hero/components/hero-dropdown.html
@@ -1,0 +1,43 @@
+<div class="bp-dropdown margin--top--sm">
+  <div class="bp-dropdown-trigger">
+    <a
+      class="bp-button bp-dropdown-button hero-dropdown is-centered"
+      aria-haspopup="true"
+      aria-controls="hero-dropdown-menu"
+    >
+      {%- if section.hero.dropdown.title -%}
+      <span>
+        <b>
+          <p>{{- section.hero.dropdown.title -}}</p>
+        </b>
+      </span>
+      {%- else -%}
+      <span>
+        <b>
+          <p>I want to...</p>
+        </b>
+      </span>
+      {%- endif -%}
+      <span class="icon is-small">
+        <i
+          class="sgds-icon sgds-icon-chevron-down is-size-4"
+          aria-hidden="true"
+        ></i>
+      </span>
+    </a>
+  </div>
+  <div
+    class="bp-dropdown-menu has-text-left"
+    id="hero-dropdown-menu"
+    role="menu"
+  >
+    <div class="bp-dropdown-content is-centered">
+      {%- for option in section.hero.dropdown.options -%} {%- if option.url and
+      option.title -%}
+      <a class="bp-dropdown-item" href="{{- site.baseurl -}}{{ option.url }}">
+        <h5>{{ option.title }}</h5>
+      </a>
+      {%- endif -%} {%- endfor -%}
+    </div>
+  </div>
+</div>

--- a/_includes/homepage/hero/components/hero-infobox-desktop.html
+++ b/_includes/homepage/hero/components/hero-infobox-desktop.html
@@ -11,9 +11,11 @@
       <p class="is-hidden-touch body-2">{{- section.hero.subtitle -}}</p>
       {%- endif -%}
     </div>
-    {%- if section.hero.dropdown -%} {% include
-    homepage/hero/components/hero-dropdown.html %} {% else %} {%- if
-    section.hero.url and section.hero.button -%}
+    {%- if section.hero.dropdown -%}
+    <div class="is-flex" style="justify-content: center; align-content: center">
+      {% include homepage/hero/components/hero-dropdown.html %}
+    </div>
+    {% else %} {%- if section.hero.url and section.hero.button -%}
     <a
       href="{{- site.baseurl -}}{{- section.hero.url -}}"
       class="bp-button is-secondary is-uppercase search-button"

--- a/_includes/homepage/hero/components/hero-infobox-desktop.html
+++ b/_includes/homepage/hero/components/hero-infobox-desktop.html
@@ -11,13 +11,15 @@
       <p class="is-hidden-touch body-2">{{- section.hero.subtitle -}}</p>
       {%- endif -%}
     </div>
-    {%- if section.hero.url and section.hero.button -%}
+    {%- if section.hero.dropdown -%} {% include
+    homepage/hero/components/hero-dropdown.html %} {% else %} {%- if
+    section.hero.url and section.hero.button -%}
     <a
       href="{{- site.baseurl -}}{{- section.hero.url -}}"
       class="bp-button is-secondary is-uppercase search-button"
     >
       {{- section.hero.button -}}
     </a>
-    {%- endif -%}
+    {%- endif -%} {%- endif -%}
   </div>
 </div>

--- a/_includes/homepage/hero/components/hero-infobox-desktop.html
+++ b/_includes/homepage/hero/components/hero-infobox-desktop.html
@@ -15,13 +15,13 @@
     <div class="is-flex" style="justify-content: center; align-content: center">
       {% include homepage/hero/components/hero-dropdown.html %}
     </div>
-    {% else %} {%- if section.hero.url and section.hero.button -%}
+    {% elsif section.hero.url and section.hero.button -%}
     <a
       href="{{- site.baseurl -}}{{- section.hero.url -}}"
       class="bp-button is-secondary is-uppercase search-button"
     >
       {{- section.hero.button -}}
     </a>
-    {%- endif -%} {%- endif -%}
+    {%- endif -%}
   </div>
 </div>

--- a/_includes/homepage/hero/hero-side-layout.html
+++ b/_includes/homepage/hero/hero-side-layout.html
@@ -30,15 +30,15 @@
         </h1>
       </div>
       {%- if section.hero.dropdown -%} {% include
-      homepage/hero/components/hero-dropdown.html %} {% else %} {%- if
-      section.hero.url and section.hero.button -%}
+      homepage/hero/components/hero-dropdown.html %} {% elsif section.hero.url
+      and section.hero.button -%}
       <a
         href="{{- site.baseurl -}}{{- section.hero.url -}}"
         class="bp-button is-secondary is-uppercase search-button"
       >
         {{- section.hero.button -}}
       </a>
-      {%- endif -%} {%- endif -%}
+      {%- endif -%}
     </div>
   </div>
 </div>

--- a/_includes/homepage/hero/hero-side-layout.html
+++ b/_includes/homepage/hero/hero-side-layout.html
@@ -29,14 +29,16 @@
           <b class="is-hidden-desktop">{{- section.hero.title -}}</b>
         </h1>
       </div>
-      {%- if section.hero.url and section.hero.button -%}
+      {%- if section.hero.dropdown -%} {% include
+      homepage/hero/components/hero-dropdown.html %} {% else %} {%- if
+      section.hero.url and section.hero.button -%}
       <a
         href="{{- site.baseurl -}}{{- section.hero.url -}}"
         class="bp-button is-secondary is-uppercase search-button"
       >
         {{- section.hero.button -}}
       </a>
-      {%- endif -%}
+      {%- endif -%} {%- endif -%}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Problem
Currently we only have a single variant for the hero banner, which is the version with highlights. This adds the [dropdown](https://www.figma.com/file/teqEgFdMSMqRVtw8jajlup/Website-Template?type=design&node-id=7313-130232&mode=dev) variant

## Solution
- shift dropdown out into its own `includes`
- use (copy-pasetd) the existing conditional for dropdown display