### PR TITLE
fix(helpers): add important rule and breakpoints to utility classes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,7 +16,7 @@
             {{- page.description | markdownify | normalize_whitespace | strip_html | strip_newlines | normalize_whitespace | truncatewords: 20 -}}
         {%- else -%}
             {{- page.content | markdownify | normalize_whitespace | strip_html | strip_newlines | normalize_whitespace | truncatewords: 20 -}}
-        {%- endif -%}"> 
+        {%- endif -%}">
     <meta name="Description" CONTENT="
         {%- if page.description -%}
             {{- page.description | markdownify | normalize_whitespace | strip_html | strip_newlines | normalize_whitespace | truncatewords: 20 -}}
@@ -33,14 +33,14 @@
     {%- endif -%}">
     <meta property="og:url" content="{{- page.url | absolute_url -}}">
     <link rel="canonical" href="{{- page.url | absolute_url -}}" />
-    
+
     {%- if site.favicon -%}
         <link rel="shortcut icon" href="{{- site.baseurl- }}{{- site.favicon -}}" type="image/x-icon">
     {%- else -%}
         <link rel="shortcut icon" href="{{- site.baseurl -}}/assets/img/favicon.ico" type="image/x-icon">
     {%- endif -%}
-    
-    <link rel="stylesheet" href="{{- site.baseurl -}}/assets/scss/styles.css">
+
+    <link rel="stylesheet" href="{{- site.baseurl -}}/assets/css/styles.css">
     <link rel="stylesheet" href="{{- site.baseurl -}}/assets/css/blueprint.css">
     <link rel="stylesheet" href="{{- site.baseurl -}}{{- site.custom_css_path -}}">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,600" crossorigin="anonymous">

--- a/_sass/helpers.scss
+++ b/_sass/helpers.scss
@@ -8,6 +8,7 @@
 */
 
 $spaceamounts: (
+  "auto",
   0,
   1,
   2,
@@ -39,46 +40,71 @@ $spaceamounts: (
   80,
   96
 );
-$sides: (top, bottom, left, right);
+// $sides: (top, bottom, left, right);
+$sides: (
+  "t": "top",
+  "b": "bottom",
+  "l": "left",
+  "r": "right",
+  "x": (
+    "left",
+    "right",
+  ),
+  "y": (
+    "top",
+    "bottom",
+  ),
+  "": (
+    "top",
+    "bottom",
+    "left",
+    "right",
+  ),
+);
 
-@each $space in $spaceamounts {
-  $remSpace: calc(#{$space}rem / 4);
+@each $breakpoint, $minwidth in $breakpoints {
+  @if $minwidth != 0px {
+    @media (min-width: $minwidth) {
+      @each $space in $spaceamounts {
+        $remSpace: if($space == "auto", auto, calc(#{$space}rem / 4));
 
-  @each $side in $sides {
-    .m#{str-slice($side, 0, 1)}-#{$space} {
-      margin-#{$side}: $remSpace !important;
+        @each $prefix, $positions in $sides {
+          $suffix: #{$prefix};
+          @if $minwidth != 0px {
+            $suffix: #{$prefix}-#{$breakpoint};
+          }
+
+          .m#{$suffix}-#{$space} {
+            @each $position in $positions {
+              margin-#{$position}: $remSpace !important;
+            }
+          }
+
+          .p#{$suffix}-#{$space} {
+            @each $position in $positions {
+              padding-#{$position}: $remSpace !important;
+            }
+          }
+        }
+      }
     }
+  } @else {
+    @each $space in $spaceamounts {
+      $remSpace: if($space == "auto", auto, calc(#{$space}rem / 4));
 
-    .p#{str-slice($side, 0, 1)}-#{$space} {
-      padding-#{$side}: $remSpace !important;
+      @each $prefix, $positions in $sides {
+        .m#{$prefix}-#{$space} {
+          @each $position in $positions {
+            margin-#{$position}: $remSpace !important;
+          }
+        }
+
+        .p#{$prefix}-#{$space} {
+          @each $position in $positions {
+            padding-#{$position}: $remSpace !important;
+          }
+        }
+      }
     }
-  }
-
-  .mx-#{$space} {
-    margin-left: $remSpace !important;
-    margin-right: $remSpace !important;
-  }
-
-  .px-#{$space} {
-    padding-left: $remSpace !important;
-    padding-right: $remSpace !important;
-  }
-
-  .my-#{$space} {
-    margin-top: $remSpace !important;
-    margin-bottom: $remSpace !important;
-  }
-
-  .py-#{$space} {
-    padding-top: $remSpace !important;
-    padding-bottom: $remSpace !important;
-  }
-
-  .m-#{$space} {
-    margin: $remSpace !important;
-  }
-
-  .p-#{$space} {
-    padding: $remSpace !important;
   }
 }

--- a/_sass/helpers.scss
+++ b/_sass/helpers.scss
@@ -46,39 +46,39 @@ $sides: (top, bottom, left, right);
 
   @each $side in $sides {
     .m#{str-slice($side, 0, 1)}-#{$space} {
-      margin-#{$side}: $remSpace;
+      margin-#{$side}: $remSpace !important;
     }
 
     .p#{str-slice($side, 0, 1)}-#{$space} {
-      padding-#{$side}: $remSpace;
+      padding-#{$side}: $remSpace !important;
     }
   }
 
   .mx-#{$space} {
-    margin-left: $remSpace;
-    margin-right: $remSpace;
+    margin-left: $remSpace !important;
+    margin-right: $remSpace !important;
   }
 
   .px-#{$space} {
-    padding-left: $remSpace;
-    padding-right: $remSpace;
+    padding-left: $remSpace !important;
+    padding-right: $remSpace !important;
   }
 
   .my-#{$space} {
-    margin-top: $remSpace;
-    margin-bottom: $remSpace;
+    margin-top: $remSpace !important;
+    margin-bottom: $remSpace !important;
   }
 
   .py-#{$space} {
-    padding-top: $remSpace;
-    padding-bottom: $remSpace;
+    padding-top: $remSpace !important;
+    padding-bottom: $remSpace !important;
   }
 
   .m-#{$space} {
-    margin: $remSpace;
+    margin: $remSpace !important;
   }
 
   .p-#{$space} {
-    padding: $remSpace;
+    padding: $remSpace !important;
   }
 }

--- a/_sass/helpers.scss
+++ b/_sass/helpers.scss
@@ -40,7 +40,6 @@ $spaceamounts: (
   80,
   96
 );
-// $sides: (top, bottom, left, right);
 $sides: (
   "t": "top",
   "b": "bottom",

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -7,4 +7,14 @@ $primary-color: {{- site.colors.primary-color -}};
 $secondary-color: {{- site.colors.secondary-color -}};
 $secondary-color-hover: lighten($secondary-color, 10%);
 
+// Minimum width before a media query is triggered
+$breakpoints: (
+  "": 0px,
+  sm: 431px,
+  md: 770px,
+  lg: 1024px,
+  xl: 1280px,
+  xxl: 1408px,
+);
+
 @import "helpers";


### PR DESCRIPTION
The margin and padding utility classes lack the `!important` CSS rule, which causes it to be ignored when used with other classes.

Using `!important` is generally bad practice, but this is okay for utility classes such as padding and margin, as you are trying to force the particular element to have the spacing that you want.

Also added breakpoint-aware padding and margin utility classes at the following breakpoints:

```
  "": 0px,
  sm: 431px,
  md: 770px,
  lg: 1024px,
  xl: 1280px,
  xxl: 1408px,
```

This follows the [convention used by Bootstrap](https://getbootstrap.com/docs/5.3/utilities/spacing/) whereby if you specify say `pb-4 pb-lg-16`, you will get `padding-bottom: 1rem` on 0px to 1023px, then `padding-bottom: 4rem` on 1024px onwards. The breakpoint numbers specifies the minimum width before the class is usable.

The breakpoints are stored in `styles.scss` so that it can be used in other components that require knowledge of the breakpoints.