### PR TITLE
Feat/mobile pagination and skip to end

### DIFF
--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -70,11 +70,13 @@
 </div> 
 <div class="search pagination padding--bottom--xl">
   <span class="bx bx-chevrons-left is-size-4"></span>
+  <div class="px-1 is-hidden-mobile"></div>
   <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
   {%- comment -%} To insert page selectors {%- endcomment -%}
   <div id="paginator-pages" class="is-hidden-mobile"></div>
   <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
   <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+  <div class="px-1 is-hidden-mobile"></div>
   <span class="bx bx-chevrons-right is-size-4"></span>
 </div>
 

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -69,7 +69,7 @@
   {{- content -}}
 </div> 
 <div class="search pagination padding--bottom--xl">
-  <span class="bx bx-chevrons-left is-size-4"></span>
+  <span class="bx bx-chevrons-left is-size-4 pointer"></span>
   <div class="px-1 is-hidden-mobile"></div>
   <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
   {%- comment -%} To insert page selectors {%- endcomment -%}
@@ -77,7 +77,7 @@
   <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
   <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
   <div class="px-1 is-hidden-mobile"></div>
-  <span class="bx bx-chevrons-right is-size-4"></span>
+  <span class="bx bx-chevrons-right is-size-4 pointer"></span>
 </div>
 
 

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -69,10 +69,13 @@
   {{- content -}}
 </div> 
 <div class="search pagination padding--bottom--xl">
-  <span class="sgds-icon sgds-icon-arrow-left is-size-4"></span>
+  <span class="bx bx-chevrons-left is-size-4"></span>
+  <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
   {%- comment -%} To insert page selectors {%- endcomment -%}
-  <div id="paginator-pages"></div>
-  <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span>
+  <div id="paginator-pages" class="is-hidden-mobile"></div>
+  <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
+  <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+  <span class="bx bx-chevrons-right is-size-4"></span>
 </div>
 
 

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -69,15 +69,15 @@
   {{- content -}}
 </div> 
 <div class="search pagination padding--bottom--xl">
-  <span class="bx bx-chevrons-left is-size-4 pointer"></span>
+  <span class="bx bx-chevrons-left is-size-4 pointer" aria-label="Skip to start"></span>
   <div class="px-1 is-hidden-mobile"></div>
-  <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+  <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only pointer" aria-label="Previous page"></span>
   {%- comment -%} To insert page selectors {%- endcomment -%}
   <div id="paginator-pages" class="is-hidden-mobile"></div>
   <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
-  <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+  <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only pointer" aria-label="Next page"></span>
   <div class="px-1 is-hidden-mobile"></div>
-  <span class="bx bx-chevrons-right is-size-4 pointer"></span>
+  <span class="bx bx-chevrons-right is-size-4 pointer" aria-label="Skip to end"></span>
 </div>
 
 

--- a/_layouts/datagovsg-search.html
+++ b/_layouts/datagovsg-search.html
@@ -53,7 +53,7 @@ layout: skeleton
 </section>
 
 
-<div class="search pagination padding--bottom--xl">
+<div class="px-6 search pagination padding--bottom--xl">
     <span class="bx bx-chevrons-left is-size-4"></span>
     <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}

--- a/_layouts/datagovsg-search.html
+++ b/_layouts/datagovsg-search.html
@@ -54,10 +54,13 @@ layout: skeleton
 
 
 <div class="search pagination padding--bottom--xl">
-    <span class="sgds-icon sgds-icon-arrow-left is-size-4"></span>
+    <span class="bx bx-chevrons-left is-size-4"></span>
+    <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}
-    <div id="paginator-pages"></div>
-    <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span>
+    <div id="paginator-pages" class="is-hidden-mobile"></div>
+    <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
+    <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+    <span class="bx bx-chevrons-right is-size-4"></span>
 </div>
 
 <span style="display: none;" id="resourceId">{{- page.datagovsg-id -}}</span>

--- a/_layouts/datagovsg-search.html
+++ b/_layouts/datagovsg-search.html
@@ -55,11 +55,13 @@ layout: skeleton
 
 <div class="px-6 search pagination padding--bottom--xl">
     <span class="bx bx-chevrons-left is-size-4"></span>
+    <div class="px-1 is-hidden-mobile"></div>
     <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}
     <div id="paginator-pages" class="is-hidden-mobile"></div>
     <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
     <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+    <div class="px-1 is-hidden-mobile"></div>
     <span class="bx bx-chevrons-right is-size-4"></span>
 </div>
 

--- a/_layouts/events-listing.html
+++ b/_layouts/events-listing.html
@@ -131,8 +131,11 @@ layout: skeleton
 </section>
 
 <div class="search pagination padding--bottom--xl">
-    <span class="sgds-icon sgds-icon-arrow-left is-size-4"></span>
+    <span class="bx bx-chevrons-left is-size-4"></span>
+    <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}
-    <div id="paginator-pages"></div>
-    <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span>
+    <div id="paginator-pages" class="is-hidden-mobile"></div>
+    <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
+    <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+    <span class="bx bx-chevrons-right is-size-4"></span>
 </div>

--- a/_layouts/events-listing.html
+++ b/_layouts/events-listing.html
@@ -132,10 +132,12 @@ layout: skeleton
 
 <div class="px-6 search pagination padding--bottom--xl">
     <span class="bx bx-chevrons-left is-size-4"></span>
+    <div class="px-1 is-hidden-mobile"></div>
     <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}
     <div id="paginator-pages" class="is-hidden-mobile"></div>
     <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
     <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+    <div class="px-1 is-hidden-mobile"></div>
     <span class="bx bx-chevrons-right is-size-4"></span>
 </div>

--- a/_layouts/events-listing.html
+++ b/_layouts/events-listing.html
@@ -130,7 +130,7 @@ layout: skeleton
     </div>
 </section>
 
-<div class="search pagination padding--bottom--xl">
+<div class="px-6 search pagination padding--bottom--xl">
     <span class="bx bx-chevrons-left is-size-4"></span>
     <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}

--- a/_layouts/resources-alt.html
+++ b/_layouts/resources-alt.html
@@ -102,7 +102,7 @@ layout: skeleton
     </div>
 </section>
 
-<div class="search pagination padding--bottom--xl">
+<div class="px-6 search pagination padding--bottom--xl">
     <span class="bx bx-chevrons-left is-size-4"></span>
     <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}

--- a/_layouts/resources-alt.html
+++ b/_layouts/resources-alt.html
@@ -103,8 +103,11 @@ layout: skeleton
 </section>
 
 <div class="search pagination padding--bottom--xl">
-    <span class="sgds-icon sgds-icon-arrow-left is-size-4"></span>
+    <span class="bx bx-chevrons-left is-size-4"></span>
+    <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}
-    <div id="paginator-pages"></div>
-    <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span>
+    <div id="paginator-pages" class="is-hidden-mobile"></div>
+    <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
+    <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+    <span class="bx bx-chevrons-right is-size-4"></span>
 </div>

--- a/_layouts/resources-alt.html
+++ b/_layouts/resources-alt.html
@@ -104,10 +104,12 @@ layout: skeleton
 
 <div class="px-6 search pagination padding--bottom--xl">
     <span class="bx bx-chevrons-left is-size-4"></span>
+    <div class="px-1 is-hidden-mobile"></div>
     <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}
     <div id="paginator-pages" class="is-hidden-mobile"></div>
     <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
     <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+    <div class="px-1 is-hidden-mobile"></div>
     <span class="bx bx-chevrons-right is-size-4"></span>
 </div>

--- a/_layouts/resources.html
+++ b/_layouts/resources.html
@@ -91,10 +91,12 @@ layout: skeleton
 
 <div class="px-6 search pagination padding--bottom--xl">
     <span class="bx bx-chevrons-left is-size-4"></span>
+    <div class="px-1 is-hidden-mobile"></div>
     <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}
     <div id="paginator-pages" class="is-hidden-mobile"></div>
     <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
     <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+    <div class="px-1 is-hidden-mobile"></div>
     <span class="bx bx-chevrons-right is-size-4"></span>
 </div>

--- a/_layouts/resources.html
+++ b/_layouts/resources.html
@@ -89,7 +89,7 @@ layout: skeleton
 </section>
 
 
-<div class="search pagination padding--bottom--xl">
+<div class="px-6 search pagination padding--bottom--xl">
     <span class="bx bx-chevrons-left is-size-4"></span>
     <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}

--- a/_layouts/resources.html
+++ b/_layouts/resources.html
@@ -90,8 +90,11 @@ layout: skeleton
 
 
 <div class="search pagination padding--bottom--xl">
-    <span class="sgds-icon sgds-icon-arrow-left is-size-4"></span>
+    <span class="bx bx-chevrons-left is-size-4"></span>
+    <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}
-    <div id="paginator-pages"></div>
-    <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span>
+    <div id="paginator-pages" class="is-hidden-mobile"></div>
+    <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
+    <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+    <span class="bx bx-chevrons-right is-size-4"></span>
 </div>

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -59,7 +59,7 @@ layout: skeleton
     </div>
 </section>
 
-<div class="search pagination padding--bottom--xl">
+<div class="px-6 search pagination padding--bottom--xl">
 	<span class="bx bx-chevrons-left is-size-4"></span>
 	<span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
 	{%- comment -%} To insert page selectors {%- endcomment -%}

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -60,8 +60,11 @@ layout: skeleton
 </section>
 
 <div class="search pagination padding--bottom--xl">
-	<span class="sgds-icon sgds-icon-arrow-left is-size-4"></span>
+	<span class="bx bx-chevrons-left is-size-4"></span>
+	<span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
 	{%- comment -%} To insert page selectors {%- endcomment -%}
-	<div id="paginator-pages"></div>
-	<span class="sgds-icon sgds-icon-arrow-right is-size-4"></span>
+	<div id="paginator-pages" class="is-hidden-mobile"></div>
+	<div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
+	<span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+	<span class="bx bx-chevrons-right is-size-4"></span>
 </div>

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -61,10 +61,12 @@ layout: skeleton
 
 <div class="px-6 search pagination padding--bottom--xl">
 	<span class="bx bx-chevrons-left is-size-4"></span>
+	<div class="px-1 is-hidden-mobile"></div>
 	<span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
 	{%- comment -%} To insert page selectors {%- endcomment -%}
 	<div id="paginator-pages" class="is-hidden-mobile"></div>
 	<div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
 	<span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+	<div class="px-1 is-hidden-mobile"></div>
 	<span class="bx bx-chevrons-right is-size-4"></span>
 </div>

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -10891,6 +10891,7 @@ h6 center {
   text-decoration: none;
 }
 .pagination span {
+  flex: 0 0 3rem;
   width: 3rem;
   line-height: 3rem;
   border: 1px solid #d6d6d6;
@@ -10915,7 +10916,6 @@ h6 center {
   border: 1px solid #d6d6d6;
 }
 .pagination span.sgds-icon {
-  padding: 0 3rem 0 2rem;
   margin: 0 0.75rem;
 }
 .pagination .selected-page {
@@ -11585,7 +11585,7 @@ h6 center {
   border-bottom: 1px solid #D6D6D6;
 }
 .remove-border {
-  border: none;
+  border: none !important;
 }
 .datagov-focus-border:focus {
   border: 2px solid #000AFF;

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -210,6 +210,7 @@ function displaySearchFilterDropdown(fields, startingField) {
 function displayPagination(index) {
   document.querySelector(".pagination").style.display = "flex";
   var pagination = document.getElementById('paginator-pages');
+  const paginationMobile = document.getElementById('paginator-pages-mobile')
   const totalPages = Math.ceil(datagovsgTotal / PAGINATION_DISPLAY_RESULTS_PER_PAGE)
 
   for (var i = 0; i < totalPages; i++) {
@@ -225,6 +226,16 @@ function displayPagination(index) {
     pagination.appendChild(ele);
   }
 
+  // Create page display for mobile
+  if (paginationMobile) {
+    const ele = document.createElement("span")
+    const text = document.createTextNode(`Page ${index}`)
+    ele.classList.add("is-full-height", "is-full-width", "remove-border")
+    ele.style.width = "100%"
+    ele.appendChild(text)
+    paginationMobile.appendChild(ele)
+  }
+  
   // Initialise selected page and nav arrows
   setCurrentPage(pagination.childNodes[index]);
   displayNavArrows(currentPageIndex);
@@ -256,18 +267,4 @@ function shouldCallAPI(index) {
   if (index < 0) return false
   if (index > datagovsgTotal / PAGINATION_DISPLAY_RESULTS_PER_PAGE) return false
   return true
-
-  // Checks to make sure that the last digit of the page number is greater than 5.
-  // i.e. we should call the API for the next 100 rows if the user is currently at 
-  // page number 26.
-  // Note: the index starts from 0, so a page index of 14 corresponds to a page number of 15.
-  if (index % 10 < 4) return false;
-
-  // Makes sure that there is more data to be retrieved from the API.
-  if (datagovsgOffset + 100 > datagovsgTotal) return false;
-
-  // Makes sure that we haven't already called the API for the next 100 rows.
-  if (index * PAGINATION_DISPLAY_RESULTS_PER_PAGE < datagovsgOffset) return false;
-
-  return true;
 }

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -89,7 +89,6 @@ function databaseSearch(searchTerm, index, callback) {
       // Delay loading spinner disappearing for first render
       document.getElementById("loading-spinner").style.display = 'none';
     }
-    // hideAllPostsAndPagination();
 
     // The fieldArray is the array containing the field names in the data.gov.sg table
     const removableFields = ["_id", "_full_count", "rank", `rank ${searchField}`]

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -3,7 +3,8 @@ layout: blank
 ---
 'use strict';
 
-var RESULTS_PER_PAGE = 10;
+const PAGINATION_DISPLAY_RESULTS_PER_PAGE = 10; // Must be smaller than size of datagov pagination (100)
+const DATAGOV_API_RESULTS_PER_PAGE = 100; // Fixed by datagov
 var MAX_ADJACENT_PAGE_BTNS = 2;
 var MAX_ADJACENT_MOBILE_PAGE_BTNS = 1;
 var pageResults = [];
@@ -51,11 +52,21 @@ function getQueryVariable(variable) {
   }
 }
 
-function databaseSearch(searchTerm, index, searchField) {
+function getOffset(pageIndex) {
+  // Retrieves the offset required for the first item in the page
+  // pageIndex is 0-indexed
+  const firstElemIndex = pageIndex * PAGINATION_DISPLAY_RESULTS_PER_PAGE
+  const offsetRequired = Math.floor(firstElemIndex / DATAGOV_API_RESULTS_PER_PAGE) * DATAGOV_API_RESULTS_PER_PAGE
+  return offsetRequired
+}
+
+function databaseSearch(searchTerm, index, callback) {
+  const isFirstRender = pageResults.length === 0
   const resourceId = document.getElementById("resourceId").innerHTML;
+  const offset = getOffset(index)
   var data = {
     resource_id: resourceId, // the resource id
-    offset: datagovsgOffset
+    offset
   };
 
   if (searchTerm !== '') {
@@ -66,25 +77,48 @@ function databaseSearch(searchTerm, index, searchField) {
   var request = $.ajax({
     url: 'https://data.gov.sg/api/action/datastore_search',
     data: data,
-    dataType: 'json'
+    dataType: 'json',
+    success: callback
   });
 
   request.done(function (data) {
-    document.getElementById("loading-spinner").style.display = 'none';
-    hideAllPostsAndPagination();
+    datagovsgTotal = data.result.total;
+    if (isFirstRender) {
+      pageResults = Array(Math.ceil(datagovsgTotal / PAGINATION_DISPLAY_RESULTS_PER_PAGE)).fill(null);
+    } else {
+      // Delay loading spinner disappearing for first render
+      document.getElementById("loading-spinner").style.display = 'none';
+    }
+    // hideAllPostsAndPagination();
 
     // The fieldArray is the array containing the field names in the data.gov.sg table
-    fieldArray = remove(data.result.fields, ["_id", "_full_count", "rank", `rank ${searchField}`]);
-    pageResults = pageResults.concat(splitPages(data.result.records, RESULTS_PER_PAGE));
-    datagovsgTotal = data.result.total;
+    const removableFields = ["_id", "_full_count", "rank", `rank ${searchField}`]
+    fieldArray = remove(data.result.fields, removableFields);
+    const pageResultArray = splitPages(data.result.records, PAGINATION_DISPLAY_RESULTS_PER_PAGE)
+    const startingPage = offset / PAGINATION_DISPLAY_RESULTS_PER_PAGE
     const possibleSearchField = searchField || defaultField
     if (!hasPopulatedFields && possibleSearchField) {
       displaySearchFilterDropdown(fieldArray.map(item => item.id), possibleSearchField);
       hasPopulatedFields = true
     }
-    displayTable(pageResults[currentPageIndex], fieldArray);
-    if (!pageResults || pageResults.length <= 1) return;
-    displayPagination(index);
+    pageResultArray.forEach((pageData, idx) => {
+      pageResults[startingPage + idx] = pageData
+    })
+    if (isFirstRender) {
+      // Also preload the last set of pages if applicable
+      const finalPage = Math.ceil(datagovsgTotal / PAGINATION_DISPLAY_RESULTS_PER_PAGE) - 1
+      const renderDisplay = () => {
+        document.getElementById("loading-spinner").style.display = 'none';
+        displayTable(pageResults[currentPageIndex], fieldArray);
+        if (pageResults.length === 0) return;
+        displayPagination(index);
+      }
+      if (getOffset(finalPage) !== 0) {
+        databaseSearch(searchTerm, finalPage, renderDisplay)
+      } else {
+        renderDisplay()
+      }
+    }
   })
     .fail(function () { // Displays no results if the AJAX call fails
       document.getElementById("loading-spinner").style.display = 'none';
@@ -176,8 +210,9 @@ function displaySearchFilterDropdown(fields, startingField) {
 function displayPagination(index) {
   document.querySelector(".pagination").style.display = "flex";
   var pagination = document.getElementById('paginator-pages');
+  const totalPages = Math.ceil(datagovsgTotal / PAGINATION_DISPLAY_RESULTS_PER_PAGE)
 
-  for (var i = 0; i < pageResults.length; i++) {
+  for (var i = 0; i < totalPages; i++) {
     var ele = document.createElement("span");
     var text = document.createTextNode(i + 1);
     ele.appendChild(text);
@@ -201,14 +236,27 @@ function changePage(curr, index) {
     datagovsgOffset += 100;
     databaseSearch(searchTerm, index, searchField);
   }
+  // Always also look 5 pages ahead and behind
+  const forwardIndex = index + 5
+  const backwardIndex = index - 5
+  if (shouldCallAPI(forwardIndex)) {
+    databaseSearch(searchTerm, forwardIndex);
+  }
+  if (shouldCallAPI(backwardIndex)) {
+    databaseSearch(searchTerm, backwardIndex);
+  }
 
   changePageUtil(curr, index);
   displayTable(pageResults[currentPageIndex], fieldArray);
 }
 
-// Evaluates to true if we should call the datagovsg API for the 
-// next 100 rows of data
+// Evaluates to true if we should call the datagovsg API
 function shouldCallAPI(index) {
+  if (pageResults[index] !== null) return false
+  if (index < 0) return false
+  if (index > datagovsgTotal / PAGINATION_DISPLAY_RESULTS_PER_PAGE) return false
+  return true
+
   // Checks to make sure that the last digit of the page number is greater than 5.
   // i.e. we should call the API for the next 100 rows if the user is currently at 
   // page number 26.
@@ -219,7 +267,7 @@ function shouldCallAPI(index) {
   if (datagovsgOffset + 100 > datagovsgTotal) return false;
 
   // Makes sure that we haven't already called the API for the next 100 rows.
-  if (index * RESULTS_PER_PAGE < datagovsgOffset) return false;
+  if (index * PAGINATION_DISPLAY_RESULTS_PER_PAGE < datagovsgOffset) return false;
 
   return true;
 }

--- a/assets/js/pagination-util.js
+++ b/assets/js/pagination-util.js
@@ -20,6 +20,17 @@ function displayPagination() {
     _loop(i);
   }
 
+  // Create page display for mobile
+  const paginationMobile = document.getElementById('paginator-pages-mobile')
+  if (paginationMobile) {
+    const ele = document.createElement("span")
+    const text = document.createTextNode(`Page`)
+    ele.classList.add("is-full-height", "is-full-width", "remove-border")
+    ele.style.width = "100%"
+    ele.appendChild(text)
+    paginationMobile.appendChild(ele)
+  }
+
   // Initialise selected page and nav arrows
   setCurrentPage(pagination.firstElementChild);
   displayNavArrows(currentPageIndex);
@@ -44,7 +55,8 @@ function setNavArrowHandlers() {
   };
 
   if (farRight) farRight.onclick = function (e) {
-    changePage(pagination.lastElementChild, Math.ceil(datagovsgTotal / RESULTS_PER_PAGE) - 1);
+    const totalPages = pagination.children[pagination.children.length - 1].textContent
+    changePage(pagination.lastElementChild, totalPages - 1);
   };
   right.onclick = function (e) {
     var sel = document.querySelector("#paginator-pages .selected-page");
@@ -127,6 +139,10 @@ function setCurrentPage(ele) {
     if (pages[currentPageIndex - _i]) {
       pages[currentPageIndex - _i].classList.remove("is-hidden-mobile");
     }
+  }
+  const mobilePage = document.getElementById("paginator-pages-mobile")
+  if (mobilePage) {
+    mobilePage.children[0].textContent = `Page ${currentPageIndex + 1}`
   }
 }
 

--- a/assets/js/pagination-util.js
+++ b/assets/js/pagination-util.js
@@ -28,15 +28,24 @@ function displayPagination() {
 
 // Set click handlers for nav arrows
 function setNavArrowHandlers() {
+  var farLeft = document.querySelector(".pagination .bx.bx-chevrons-left");
   var left = document.querySelector(".pagination .sgds-icon.sgds-icon-arrow-left");
+  var farRight = document.querySelector(".pagination .bx.bx-chevrons-right");
   var right = document.querySelector(".pagination .sgds-icon.sgds-icon-arrow-right");
   var sel = document.querySelector("#paginator-pages .selected-page");
+  var pagination = document.getElementById('paginator-pages');
 
+  if (farLeft) farLeft.onclick = function (e) {
+    changePage(pagination.firstElementChild, 0);
+  };
   left.onclick = function (e) {
     var sel = document.querySelector("#paginator-pages .selected-page");
     changePage(sel.previousElementSibling, currentPageIndex - 1);
   };
 
+  if (farRight) farRight.onclick = function (e) {
+    changePage(pagination.lastElementChild, Math.ceil(datagovsgTotal / RESULTS_PER_PAGE) - 1);
+  };
   right.onclick = function (e) {
     var sel = document.querySelector("#paginator-pages .selected-page");
     changePage(sel.nextElementSibling, currentPageIndex + 1);
@@ -54,17 +63,23 @@ function changePageUtil(curr, index) {
 }
 
 function displayNavArrows(i) {
+  var farLeft = document.querySelector(".pagination .bx.bx-chevrons-left");
   var left = document.querySelector(".pagination .sgds-icon.sgds-icon-arrow-left");
+  var farRight = document.querySelector(".pagination .bx.bx-chevrons-right");
   var right = document.querySelector(".pagination .sgds-icon.sgds-icon-arrow-right");
 
   if (i === 0) {
+    if (farLeft) farLeft.classList.add("sgds-icon-disabled");
     left.classList.add("sgds-icon-disabled");
   } else {
+    if (farLeft) farLeft.classList.remove("sgds-icon-disabled");
     left.classList.remove("sgds-icon-disabled");
   }
   if (i === pageResults.length - 1) {
+    if (farRight) farRight.classList.add("sgds-icon-disabled");
     right.classList.add("sgds-icon-disabled");
   } else {
+    if (farRight) farRight.classList.remove("sgds-icon-disabled");
     right.classList.remove("sgds-icon-disabled");
   }
 }


### PR DESCRIPTION
This PR adds functionality to our existing pagination to allow skip to first/last page. It also introduces a better mobile view for both dgs pages as well as existing pages with pagination (e.g. resources, search).

[Figma](https://www.figma.com/file/owgl8SFMKQd2jrCJMVrukR/CMS-%7C-Q42023?node-id=325%3A9703&mode=dev)

Resolves IS-769

Tests:

- [ ] Pagination should be working for the following sections:
  - [ ] DGSV2
    - [ ] Skip to end
    - [ ] Skip to start
    - [ ] Side arrow (mobile)
    - [ ] Click on next page (desktop)
  - [ ] DGSV1
    - [ ] Skip to end
    - [ ] Skip to start
    - [ ] Side arrow (mobile)
    - [ ] Click on next page (desktop)
  - [ ] Resources
    - [ ] Skip to end
    - [ ] Skip to start
    - [ ] Side arrow (mobile)
    - [ ] Click on next page (desktop)
  - [ ] Search
    - [ ] Skip to end
    - [ ] Skip to start
    - [ ] Side arrow (mobile)
    - [ ] Click on next page (desktop)

Before:
(Desktop):
<img width="1064" alt="Screenshot 2023-11-15 at 5 11 27 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/0b75a7fe-f73b-4df2-a7f2-a68ae80d7798">

(Mobile):
<img width="386" alt="Screenshot 2023-11-15 at 5 11 44 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/ab10aca3-49d0-45bf-ba82-728919fa436e">


After:
(Desktop):
<img width="1076" alt="Screenshot 2023-11-15 at 5 09 13 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/2df06dbd-870f-4501-8e89-b2665ec5a7dc">


(Mobile):
<img width="694" alt="Screenshot 2023-11-15 at 5 08 49 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/6f96a9d9-8c28-4123-a905-e378c5e7864b">

Sample site:
https://staging.duyfy15grdtiq.amplifyapp.com/datagovv2/collection/
(For testing global search, use `Title`)