### PR TITLE
fix(announcements): set width 100% for row

### DIFF
--- a/_includes/homepage/announcements.html
+++ b/_includes/homepage/announcements.html
@@ -10,8 +10,8 @@
       link_url
 {%- endcomment -%}
 <section class="bp-section {{ gray_container_class }} px-14 px-md-24 py-24">
-  <div class="announcements-section mx-auto">
-    <div class="row">
+  <div class="announcements-section mx-auto is-flex">
+    <div class="row w-100">
       <div class="col is-full">
         {%- if include.subtitle -%}
         <p class="eyebrow is-uppercase mb-2 has-text-centered">

--- a/_includes/homepage/announcements.html
+++ b/_includes/homepage/announcements.html
@@ -10,7 +10,7 @@
       link_url
 {%- endcomment -%}
 <section class="bp-section {{ gray_container_class }} px-14 px-md-24 py-24">
-  <div class="announcements-section mx-auto is-flex">
+  <div class="announcements-section mx-auto">
     <div class="row">
       <div class="col is-full">
         {%- if include.subtitle -%}

--- a/_includes/homepage/announcements.html
+++ b/_includes/homepage/announcements.html
@@ -11,38 +11,38 @@
 {%- endcomment -%}
 <section class="bp-section {{ gray_container_class }} px-14 px-md-24 py-24">
   <div class="announcements-section mx-auto is-flex">
-    <div class="row w-100">
-      <div class="col is-full">
-        {%- if include.subtitle -%}
-        <p class="eyebrow is-uppercase mb-2 has-text-centered">
-          {{- include.subtitle -}}
-        </p>
-        {%- endif -%}
-        {%- if include.title -%}
-        <h1 class="has-text-secondary mb-12 has-text-centered">
-          <b>{{- include.title -}}</b>
-        </h1>
-        {%- endif -%}
+    {%- if include.subtitle -%}
+    <p class="subtitle-2 eyebrow is-uppercase mb-2 has-text-centered">
+      {{- include.subtitle -}}
+    </p>
+    {%- endif -%}
+    {%- if include.title -%}
+    <h1 class="h1 has-text-secondary mb-12 has-text-centered">
+      {{- include.title -}}
+    </h1>
+    {%- endif -%}
 
+    <div class="row w-100 m-0">
+      <div class="col is-full p-0">
         <hr class="mb-2 mt-0 announcements-divider" />
 
         {%- for announcement in include.announcement_items limit:5 -%}
         <div class="row is-desktop px-0 py-6 py-lg-0 m-0">
           <div class="col is-4-desktop p-0 p-lg-6 mb-6 mb-lg-0 mr-lg-6">
-            <h3 class="announcements-announcement-title mb-2 mb-lg-4">
-              <b>{{- announcement.title -}}</b>
+            <h3 class="h3 mb-2 mb-lg-4">
+              {{- announcement.title -}}
             </h3>
-            <p class="announcements-announcement-subtitle">
+            <p class="subtitle-1">
               {{- announcement.date -}}
             </p>
           </div>
           <div class="col p-0 p-lg-6">
-            <p>{{- announcement.announcement -}}</p>
+            <p class="body-1">{{- announcement.announcement -}}</p>
             {%- if announcement.link_text and announcement.link_url -%}
             <div class="mt-6 mt-lg-4">
               {%- assign url_input = announcement.link_url -%} {%- include
               functions/external_url.html -%}
-              <a {{anchor}} class="announcements-announcement-link">
+              <a {{anchor}} class="link">
                 <span>{{- announcement.link_text -}}</span>
               </a>
             </div>

--- a/_sass/components/homepage/_announcements.scss
+++ b/_sass/components/homepage/_announcements.scss
@@ -1,7 +1,5 @@
 .announcements-section {
   max-width: $container-max-width;
-  flex-direction: column;
-  align-items: center;
 }
 
 .announcements-divider {

--- a/_sass/components/homepage/_announcements.scss
+++ b/_sass/components/homepage/_announcements.scss
@@ -1,5 +1,7 @@
 .announcements-section {
   max-width: $container-max-width;
+  flex-direction: column;
+  align-items: center;
 }
 
 .announcements-divider {

--- a/_sass/components/homepage/_announcements.scss
+++ b/_sass/components/homepage/_announcements.scss
@@ -9,33 +9,6 @@
   color: #f9f9f9;
 }
 
-.announcements-announcement-title {
-  font-size: 1.625rem;
-  font-weight: 700;
-  line-height: 2rem;
-}
-
-.announcements-announcement-subtitle {
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.375rem;
-}
-
-.announcements-announcement-link {
-  color: $secondary-color;
-  font-size: 1.125rem;
-  font-weight: 600;
-  line-height: 1.5rem;
-  letter-spacing: 0.27px;
-  text-decoration-line: underline;
-  text-transform: capitalize;
-  text-underline-offset: 0.25rem;
-}
-
-.announcements-announcement-link:hover {
-  color: $secondary-color-hover;
-}
-
-a[target="_blank"].announcements-announcement-link::after {
+a[target="_blank"].link::after {
   content: unset;
 }

--- a/_sass/theme/_colors.scss
+++ b/_sass/theme/_colors.scss
@@ -1,5 +1,5 @@
 $canvas-base: #ffffff;
-$content-base: #000000;
+$content-base: #344054;
 $utility-theme-color: $primary-color;
 $canvas-inverse: #000000;
 $content-inverse: #ffffff;

--- a/_sass/theme/_layout.scss
+++ b/_sass/theme/_layout.scss
@@ -1,3 +1,7 @@
 .flex-end {
   justify-content: flex-end;
 }
+
+.w-100 {
+  width: 100%;
+}


### PR DESCRIPTION
This sets the row to be 100% width so that the announcements component takes up the entire possible width even when the amount of content is very little.

Summary of changes:
1. The Announcements big title will be center aligned when viewing in a very small viewport
1. The styles now match the tokens on Figma (i.e. subtitle-1, h1, etc)