### PR TITLE
fix(footer): add spacing when logos are wrapped

### DIFF
--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -10722,13 +10722,13 @@ h6 center {
 @media screen and (max-width: 768px) {
   .bp-footer ul li + li:not(.icons) {
     margin-left: 0;
-    margin-top: 15px;
+    margin-top: 16px;
   }
 }
 @media screen and (min-width: 1024px) and (max-width: 1279px) {
   .bp-footer ul li + :not(ul.footer-link-container li) {
     margin-left: 0;
-    margin-top: 15px;
+    margin-top: 16px;
   }
 }
 .bp-footer.bp-footer-links li + li {

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -10725,6 +10725,12 @@ h6 center {
     margin-top: 15px;
   }
 }
+@media screen and (min-width: 1024px) and (max-width: 1279px) {
+  .bp-footer ul li + :not(ul.footer-link-container li) {
+    margin-left: 0;
+    margin-top: 15px;
+  }
+}
 .bp-footer.bp-footer-links li + li {
   margin-left: 10px;
 }


### PR DESCRIPTION
This adds a spacing between the logos in the footer when they are wrapped, which appears in the viewports between 1024px and 1279px.

Fixes IS-592.

## Screenshots

**BEFORE**
<img width="321" alt="Screenshot 2023-10-02 at 4 01 05 PM" src="https://github.com/isomerpages/isomerpages-template/assets/27919917/58b6335a-bcf9-431f-91b7-60fc3dc3b2d5">

**AFTER**
<img width="357" alt="Screenshot 2023-10-02 at 4 01 27 PM" src="https://github.com/isomerpages/isomerpages-template/assets/27919917/c1b4f340-9773-47da-be9e-16ab1dab5b76">

**SPACING DIFFERENCE**
<img width="360" alt="Screenshot 2023-10-02 at 4 01 55 PM" src="https://github.com/isomerpages/isomerpages-template/assets/27919917/30f0feee-d1a0-4b98-8612-09b83a43e69a">