### PR TITLE
chore(hero): duplicate style changes

### DIFF
--- a/_includes/homepage/hero.html
+++ b/_includes/homepage/hero.html
@@ -14,11 +14,12 @@
   'image' -%}
   <div class="bp-hero-body hero-body-padding">
     <div class="bp-container margin--top--lg">
-      <div class="row is-vcentered is-centered ma">
-        <div class="min-height-mobile is-flex row is-vcentered is-centered">
-          {%- if section.hero.dropdown -%} {% include
-          homepage/hero/components/hero-dropdown.html %} {%- endif -%}
+      <div class="min-height-mobile is-flex is-full-width is-vh-centered">
+        {%- if section.hero.dropdown -%}
+        <div class="col is-9">
+          {% include homepage/hero/components/hero-dropdown.html %}
         </div>
+        {%- endif -%}
       </div>
     </div>
   </div>

--- a/_includes/homepage/hero/components/hero-dropdown.html
+++ b/_includes/homepage/hero/components/hero-dropdown.html
@@ -1,4 +1,4 @@
-<div class="bp-dropdown">
+<div class="bp-dropdown border-solid-grey is-full-width">
   <div class="bp-dropdown-trigger">
     <a
       class="bp-button bp-dropdown-button hero-dropdown is-centered"

--- a/_includes/homepage/hero/components/hero-infobox-desktop.html
+++ b/_includes/homepage/hero/components/hero-infobox-desktop.html
@@ -6,33 +6,36 @@
     style="flex-direction: column"
   >
     <div
-      class="mb-8 is-flex {% if section.hero.variant == 'side' %} side-section-infobox-container side-section-container-{{ section.hero.alignment | default: 'left' }} {% endif %}"
-      style="flex-direction: column"
+      class="{% if section.hero.variant == 'side' %} side-section-infobox-container {% endif %}"
+      style="display: flex; flex-direction: column; align-self: {% if section.hero.alignment == 'right' %} flex-start {% else %} flex-end {% endif %};"
     >
-      <h1 class="h1 mb-4 hero-text-color">
-        <b>{{- section.hero.title -}}</b>
-      </h1>
-      {%- if section.hero.subtitle -%}
-      <p class="is-hidden-touch body-2 hero-text-color">
-        {{- section.hero.subtitle -}}
-      </p>
+      <div class="mb-8 is-flex" style="flex-direction: column">
+        <h1 class="h1 mb-4 hero-text-color">
+          <b>{{- section.hero.title -}}</b>
+        </h1>
+        {%- if section.hero.subtitle -%}
+        <p class="is-hidden-touch body-2 hero-text-color">
+          {{- section.hero.subtitle -}}
+        </p>
+        {%- endif -%}
+      </div>
+      {%- if section.hero.dropdown -%}
+      <div
+        class="is-flex is-full-width"
+        style="justify-content: center; align-content: center"
+      >
+        {% include homepage/hero/components/hero-dropdown.html %}
+      </div>
+      {% elsif section.hero.url and section.hero.button -%}
+      <div>
+        <a
+          href="{{- site.baseurl -}}{{- section.hero.url -}}"
+          class="bp-button is-secondary is-uppercase search-button"
+        >
+          {{- section.hero.button -}}
+        </a>
+      </div>
       {%- endif -%}
     </div>
-    {%- if section.hero.dropdown -%}
-    <div class="is-flex" style="justify-content: center; align-content: center">
-      {% include homepage/hero/components/hero-dropdown.html %}
-    </div>
-    {% elsif section.hero.url and section.hero.button -%}
-    <div
-      class="{% if section.hero.variant == 'side' %} hero-alignment-{{ section.hero.alignment | default: 'left' }}  {% endif %}"
-    >
-      <a
-        href="{{- site.baseurl -}}{{- section.hero.url -}}"
-        class="bp-button is-secondary is-uppercase search-button"
-      >
-        {{- section.hero.button -}}
-      </a>
-    </div>
-    {%- endif -%}
   </div>
 </div>

--- a/_includes/homepage/hero/components/hero-infobox-mobile.html
+++ b/_includes/homepage/hero/components/hero-infobox-mobile.html
@@ -8,8 +8,8 @@
   style="
     padding-top: 106px;
     padding-bottom: 106px;
-    padding-left: 84px;
-    padding-right: 84px;
+    padding-left: 48px;
+    padding-right: 48px;
   "
 >
   <div

--- a/_includes/homepage/hero/components/hero-infobox-mobile.html
+++ b/_includes/homepage/hero/components/hero-infobox-mobile.html
@@ -13,7 +13,7 @@
   "
 >
   <div
-    class="py-8 px-12 row is-vcentered is-centered is-flex hero-background-{{-
+    class="py-8 px-12 row is-vcentered is-centered is-flex col is-9 hero-background-{{-
       section.hero.backgroundColor | default: 'white' -}}"
     style="flex-direction: column"
   >

--- a/_sass/components/homepage/_hero.scss
+++ b/_sass/components/homepage/_hero.scss
@@ -16,7 +16,7 @@
   padding: 3rem 1.5rem;
 }
 
-@media screen and (min-width: map.get($breakpoints, "md")) {
+@media screen and (min-width: map-get($breakpoints, "md")) {
   .hero-floating {
     padding: 3rem;
   }
@@ -60,7 +60,7 @@
   width: 50%;
 }
 
-@media screen and (min-width: map.get($breakpoints, "xl")) {
+@media screen and (min-width: map-get($breakpoints, "xl")) {
   .hero-side-sm {
     width: 50%;
   }
@@ -80,7 +80,7 @@
   }
 }
 
-@media screen and (max-width: (map.get($breakpoints, "xl") - 1)) {
+@media screen and (max-width: (map-get($breakpoints, "xl") - 1)) {
   .hero-side-sm {
     width: 33%;
   }

--- a/_sass/components/homepage/_hero.scss
+++ b/_sass/components/homepage/_hero.scss
@@ -60,14 +60,6 @@
   width: 50%;
 }
 
-.hero-alignment-left {
-  align-self: flex-end;
-}
-
-.hero-alignment-right {
-  align-self: flex-start;
-}
-
 @media screen and (min-width: map.get($breakpoints, "xl")) {
   .hero-side-sm {
     width: 50%;

--- a/_sass/components/homepage/_hero.scss
+++ b/_sass/components/homepage/_hero.scss
@@ -1,5 +1,9 @@
 @use "sass:map";
 
+.border-solid-gray {
+  border: 1px solid $border-light;
+}
+
 .min-height-mobile {
   min-height: 398px;
 }

--- a/_sass/theme/_breakpoints.scss
+++ b/_sass/theme/_breakpoints.scss
@@ -11,4 +11,4 @@ $breakpoints: (
 );
 
 // Maximum width of site contents
-$container-max-width: map.get($breakpoints, "xl");
+$container-max-width: map-get($breakpoints, "xl");

--- a/_sass/theme/_colors.scss
+++ b/_sass/theme/_colors.scss
@@ -7,3 +7,4 @@ $utility-secondary-color: $secondary-color;
 $canvas-translucent-grey: #00000080;
 $interaction-hover: #f9f9f9;
 $stroke-default: #d0d5dd;
+$border-light: #d6d6d6;

--- a/_sass/theme/_display.scss
+++ b/_sass/theme/_display.scss
@@ -1,7 +1,7 @@
 @use "sass:map";
 
-@media screen and (min-width: map.get($breakpoints, "lg")),
-  screen and (max-width: (map.get($breakpoints, "md") - 1)) {
+@media screen and (min-width: map-get($breakpoints, "lg")),
+  screen and (max-width: (map-get($breakpoints, "md") - 1)) {
   .is-visible-tablet-only {
     display: none !important;
   }

--- a/_sass/theme/_layout.scss
+++ b/_sass/theme/_layout.scss
@@ -5,3 +5,12 @@
 .w-100 {
   width: 100%;
 }
+
+.is-full-width {
+  width: 100%;
+}
+
+.is-vh-centered {
+  align-items: center;
+  justify-content: center;
+}

--- a/_sass/theme/_layout.scss
+++ b/_sass/theme/_layout.scss
@@ -2,6 +2,10 @@
   justify-content: flex-end;
 }
 
+.flex-start {
+  justify-content: flex-start;
+}
+
 .w-100 {
   width: 100%;
 }


### PR DESCRIPTION
## Problem
Changes from frontend need to be duplicated over. This PR also adds in abit more stuff in the last 3 commits, which will be detailed below

## Solution
Previously, our dropdown tried to fit the whole infobox area in wider layouts, which was unaesthetic. The current commit fixes teh infobox to `576px` max width and we also apply this to our dropdown

Additionally, we now **always** left align items for side layout as per design's requests.

last change to alter `map.get` to `map-get` allows `remote-theme` to pass successfully. suggestive of a compat issue but idw to bother digging because it is likely to be a build level issue with sass + no easy solution anyway...

## Screenshots
### dropdown behaviour on large (>1280) screens
<img width="947" alt="Screenshot 2023-10-03 at 2 43 54 AM" src="https://github.com/isomerpages/isomerpages-template/assets/44049504/1d409180-22cd-4672-b899-4e2154177c3b">

### text align behaviour
<img width="1128" alt="Screenshot 2023-10-03 at 2 44 27 AM" src="https://github.com/isomerpages/isomerpages-template/assets/44049504/638de8e0-8b90-4d75-bf34-c8c889962220">
**note how the inner text is left aligned to an invisible bounding box**

### Small screen behaviour
<img width="359" alt="Screenshot 2023-10-03 at 2 45 29 AM" src="https://github.com/isomerpages/isomerpages-template/assets/44049504/66cc5381-bb3d-4305-a15a-f1a42e867811">
**note: no overflow**