### PR TITLE
feat(ci): add percy for visual regression testing

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,58 @@
+name: Visual regression testing using Percy
+
+on:
+  pull_request:
+    branches:
+      - "next-gen"
+  push:
+    branches:
+      - "next-gen-develop"
+
+env:
+  # The slug for the Isomer core team
+  ISOMER_CORE_TEAM_SLUG: core
+  # The location of the template regression test repository
+  ISOMER_TEMPLATE_REGRESSION_TEST: isomerpages/template-regression-test
+
+jobs:
+  snapshot:
+    name: Take snapshot
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      # Determine if the PR created is from a trusted member
+      - name: Check if user is part of Isomer core team
+        uses: tspascoal/get-user-teams-membership@v2
+        id: checkUserMember
+        with:
+          username: ${{ github.actor }}
+          team: ${{ env.ISOMER_CORE_TEAM_SLUG }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }} # requires read:org
+
+      - name: Checkout template regression testing repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.ISOMER_TEMPLATE_REGRESSION_TEST }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.6"
+
+      - name: Build the template regression testing site
+        run: |
+          bundle install
+          curl https://raw.githubusercontent.com/opengovsg/isomer-build/amplify-next-gen-staging/build.sh | bash
+
+      - name: Install percy CLI
+        run: npm install @percy/cli
+
+      - name: Take snapshots of built site
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+        run: npx percy snapshot _site/

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - "next-gen-develop"
+  workflow_dispatch:
 
 env:
   # The slug for the Isomer core team
@@ -42,7 +43,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.6"
+          ruby-version: "2.7.2"
 
       - name: Build the template regression testing site
         run: |


### PR DESCRIPTION
This adds a new CI/CD workflow to perform regression testing on our template using percy. The rough steps are:

1. Clone and build the `template-regression-test` repo in the same way that our other sites are built, using the `next-gen-staging` branch of this template repository.
2. Take snapshots of the built site using percy on the generated `_site` folder.

Note: I am intentionally not force pushing to `next-gen-staging` as it is already done through the deployment job. Also, we are limited to only 25,000 snapshots per month, which might be easily hit if we have many pages on the regression template. For now it should be fine but we will fine-tune if we run into this limit.