### PR TITLE
Fix/default bg color

### DIFF
--- a/_includes/homepage/hero/components/hero-infobox-desktop.html
+++ b/_includes/homepage/hero/components/hero-infobox-desktop.html
@@ -2,7 +2,7 @@
   class="is-flex {% if section.hero.alignment == 'right' %} flex-end {% else %} flex-start {% endif %}"
 >
   <div
-    class="p-16 hero-background-{{- section.hero.backgroundColor }} is-flex hero-{{ section.hero.variant }}-{{- section.hero.size | default: 'md' -}}"
+    class="p-16 hero-background-{{- section.hero.backgroundColor | default: 'white' }} is-flex hero-{{ section.hero.variant }}-{{- section.hero.size | default: 'md' -}}"
     style="flex-direction: column"
   >
     <div

--- a/_sass/components/homepage/_hero.scss
+++ b/_sass/components/homepage/_hero.scss
@@ -65,10 +65,6 @@
     width: 50%;
   }
 
-  .side-section-infobox-container {
-    max-width: 576px;
-  }
-
   .side-section-container-left {
     text-align: right;
     align-self: flex-end;
@@ -77,6 +73,18 @@
   .side-section-container-right {
     text-align: left;
     align-self: flex-start;
+  }
+}
+
+@media screen and (min-width: map-get($breakpoints, "xxl")) {
+  .side-section-infobox-container {
+    width: 576px;
+  }
+}
+
+@media screen and (max-width: (map-get($breakpoints, "xxl") - 1)) {
+  .side-section-infobox-container {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Problem
default bg colour missed out on 1 place + resizing behaviour for side variant of hero on 1408 -> 1280 screen sizes.

## Solution
there's a special fix for side container due to resizing behaviour on big screens. because our desired width is `576px` +`64px` on each side, we require `1408px` to display successfully before it starts cutting into the text. 

to avoid this, we set `w=100%` when width is less than `1408px`. 