### PR TITLE
Fix: footer navigation height

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -224,13 +224,13 @@ layout: skeleton
                 {%- assign prevIndex = forloop.index0 | minus: 1 -%}
                 {%- assign nextIndex = forloop.index0 | plus: 1 -%}
 
-                <section class="bp-section bottom-navigation">
-                    <div>
-                        <a href="{{- collection[prevIndex].url -}}" class="is-half is-left">
+                <section class="bp-section bottom-navigation is-flex">
+                    <div class="is-full-width">
+                        <a href="{{- collection[prevIndex].url -}}" class="is-half is-left is-full-height">
                             <p class="has-text-weight-semibold"><span class="sgds-icon sgds-icon-arrow-left is-size-4"></span> PREVIOUS </p>
                             <p class="is-hidden-mobile">{{- collection[prevIndex].title -}}</p>
                         </a>
-                        <a href="{{- collection[nextIndex].url -}}" class="is-half is-right">
+                        <a href="{{- collection[nextIndex].url -}}" class="is-half is-right is-full-height">
                             <p class="has-text-weight-semibold">NEXT <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span></p>
                             <p class="is-hidden-mobile">{{- collection[nextIndex].title -}}</p>
                         </a>

--- a/_sass/theme/_layout.scss
+++ b/_sass/theme/_layout.scss
@@ -14,6 +14,10 @@
   width: 100%;
 }
 
+.is-full-height {
+  height: 100%;
+}
+
 .is-vh-centered {
   align-items: center;
   justify-content: center;

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -4875,7 +4875,7 @@ table.table-h tbody tr:last-child th {
 }
 
 .bottom-navigation {
-  height: 95px;
+  height: max-content;
 }
 @media screen and (max-width: 768px) {
   .bottom-navigation {


### PR DESCRIPTION
This PR fixes an issue where the footer navigation would break if one section wrapped to a different line. Resolves is-593.
 
Before:
![image-20230921-024822](https://github.com/isomerpages/isomerpages-template/assets/22111124/d38f36e9-f681-4a20-acdd-62108ee298ea)

After:
<img width="1070" alt="Screenshot 2023-10-13 at 4 11 50 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/a16f4566-c3f7-47f8-8e90-cc31a24999c2">
