### PR TITLE
Feat/datagovsg v2 third nav formatting

### DIFF
--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -1,0 +1,38 @@
+<!-- Search bar display -->
+<div class="pb-12">
+  <form action="{{site.baseurl}}{{page.url}}" method="get">
+      <div class="row">
+          <div id="database-search-container" class="col">
+          <div class="field has-addons">
+              <div class="control has-icons-left is-expanded">
+                  <input class="input is-fullwidth is-large has-border-grey-light" id="search-box-datagovsg" type="text" placeholder="What are you looking for?" name="query" autocomplete="off">
+                  <span class="is-large is-left">
+                      <i class="sgds-icon sgds-icon-search is-size-4 search-bar"></i>
+                  </span>
+
+              </div>
+              <div class="control">
+                  <button type="submit" class="bp-button is-secondary is-medium has-text-white search-button">SEARCH</button>
+              </div>
+          </div>
+          </div>
+      </div>
+  </form>
+</div>
+<div id="loading-spinner" class="col is-full">
+  <div class="lds-default">
+      <div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div>
+  </div>
+</div>
+<div class="col is-full content horizontal-scroll datagovsg-table">
+  {{- content -}}
+</div> 
+<div class="search pagination padding--bottom--xl">
+  <span class="sgds-icon sgds-icon-arrow-left is-size-4"></span>
+  {%- comment -%} To insert page selectors {%- endcomment -%}
+  <div id="paginator-pages"></div>
+  <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span>
+</div>
+
+
+<span style="display: none;" id="resourceId">{{- page.datagovsg-id -}}</span>

--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -48,6 +48,14 @@
 <script src="{{- "/assets/js/datagovsg-search.js" | relative_url -}}" crossorigin="anonymous"></script>
 {%- endif -%}
 
+{%- if page.layout == 'datagovsg-v2-search' -%}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.11/purify.min.js" integrity="sha384-ELH09WGRUcBpRT6iHTekFB2YBCT9kFMsKG4Y9LUAevHjihu8Otri8Sm01QgXOTht" crossorigin="anonymous"></script>
+<script src="{{- "/assets/js/pagination-util.js" | relative_url -}}" crossorigin="anonymous"></script>
+<script src="{{- "/assets/js/search.js" | relative_url -}}" crossorigin="anonymous"></script>
+<script src="{{- "/assets/js/datagovsg-search.js" | relative_url -}}" crossorigin="anonymous"></script>
+<script src="{{- "/assets/js/left-nav-interaction.js" | relative_url -}}" crossorigin="anonymous"></script>
+{%- endif -%}
+
 {%- if page.layout == 'resources-alt' or page.layout == 'resources' -%}
 <script src="{{- "/assets/js/pagination-util.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/paginate-resources.js" | relative_url -}}" crossorigin="anonymous"></script>

--- a/_layouts/datagovsg-v2-search.html
+++ b/_layouts/datagovsg-v2-search.html
@@ -1,0 +1,229 @@
+---
+layout: skeleton
+---
+<section class="bp-section is-small bp-section-pagetitle">
+    <div class="bp-container ">
+        <div class="row">
+            <div class="col">
+                {%- include header-breadcrumb.html -%}
+            </div>
+        </div>
+    </div>
+    <div class="bp-container">
+        <div class="row">
+            <div class="col">
+                <h1 class="has-text-white"><b>{{- page.title -}}</b></h1>
+            </div>
+        </div>
+    </div>
+</section>
+
+{%- if page.collection and page.collection != "posts" -%}
+    {%- comment -%} Page is a leftnav page {%- endcomment -%}
+    {%- assign collection = site[page.collection] -%}
+    <section class="bp-section padding--none is-hidden-desktop">
+        <div class="bp-dropdown is-hoverable">
+            <div class="bp-dropdown-trigger">
+                <a class="bp-button bp-dropdown-button is-fullwidth" aria-haspopup="true" aria-controls="dropdown-menu">
+                    <span><b><p>{{- page.title -}}</p></b></span>
+                    <span class="icon is-small">
+                        <i class="sgds-icon sgds-icon-chevron-down is-size-4" aria-hidden="true"></i>
+                    </span>
+                </a>
+            </div>
+            <div class="bp-dropdown-menu has-text-left hide" id="dropdown-menu" role="menu">
+                <div class="bp-dropdown-content">
+                    {%- assign prev_third_nav_title = "" -%}
+                    {%- assign in_third_nav = false -%}
+
+                    {%- for collection_doc in collection -%}
+                        {%- if collection_doc.third_nav_title -%}
+                            {%- comment -%} If this is a third level nav page {%- endcomment -%}
+                            {%- if prev_third_nav_title != collection_doc.third_nav_title -%}
+                                {%- if in_third_nav -%}
+                                    {%- comment -%} Different third nav, end previous third nav block and start new block {%- endcomment -%}
+                                    </div>
+                                {%- endif -%}
+
+                                {%- assign anchor_colour = "" -%}
+                                {%- assign chevron_direction = "down" -%}
+                                {%- assign hidden = "is-hidden" -%}
+                                {%- if page.third_nav_title == collection_doc.third_nav_title -%}
+                                    {%- assign anchor_colour = "has-text-secondary has-text-weight-bold" -%}
+                                    {%- assign chevron_direction = "up" -%}
+                                    {%- assign hidden = "" -%}
+                                {%- endif -%}
+
+                                <a class="bp-dropdown-item third-level-nav-header-mobile {{ anchor_colour }}">
+                                    <p>{{- collection_doc.third_nav_title -}}<i class="sgds-icon sgds-icon-chevron-{{ chevron_direction }} is-pulled-right is-size-4" aria-hidden="true"></i></p>
+                                </a>
+                                <div class="third-level-nav-div-mobile {{ hidden }}">
+                                {%- assign prev_third_nav_title = collection_doc.third_nav_title -%}
+                                {%- assign in_third_nav = true -%}
+                            {%- endif -%}
+
+                            {%- assign anchor_colour = "" -%}
+                            {%- if page.url == collection_doc.url -%}
+                                {%- assign anchor_colour = "has-text-secondary has-text-weight-bold" -%}
+                            {%- endif -%}
+
+                            <a class="bp-dropdown-item third-level-nav-item-mobile {{ anchor_colour }}" href="{{- collection_doc.url -}}">
+                                <p>{{- collection_doc.title -}}</p>
+                            </a>
+                        {%- else -%}
+                            {%- comment -%} If this is not a third level nav page {%- endcomment -%}
+                            {%- if in_third_nav -%}
+                                {%- comment -%} End previous third nav block {%- endcomment -%}
+                                </div>
+                                {%- assign in_third_nav = false -%}
+                            {%- endif -%}
+
+                            {%- assign anchor_colour = "" -%}
+                            {%- if page.url == collection_doc.url -%}
+                                {%- assign anchor_colour = "has-text-secondary has-text-weight-bold" -%}
+                            {%- endif -%}
+
+                            <a class="bp-dropdown-item third-level-nav-item-mobile {{ anchor_colour }}" href="{{- collection_doc.url -}}">
+                                <p>{{- collection_doc.title -}}</p>
+                            </a>
+                        {%- endif -%}
+                        {%- if forloop.last and in_third_nav -%}
+                            </div>
+                        {%- endif -%}
+                    {%- endfor -%}
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="bp-section">
+        <div class="bp-container padding--top--lg padding--bottom--xl">
+            <div class="row">
+                <div class="col is-2 is-position-relative has-side-nav is-hidden-touch">
+                    <div class="sidenav">
+                        <aside class="bp-menu is-gt sidebar__inner">
+                            <ul class="bp-menu-list">
+                                {%- assign prev_third_nav_title = "" -%}
+                                {%- assign in_third_nav = false -%}
+
+                                {%- for collection_doc in site[page.collection] -%}
+                                    {%- if collection_doc.third_nav_title -%}
+                                        {%- comment -%} If this is a third level nav page {%- endcomment -%}
+                                        {%- if prev_third_nav_title != collection_doc.third_nav_title -%}
+                                            {%- if in_third_nav -%}
+                                                {%- comment -%} Different third nav, end previous third nav block and start new block {%- endcomment -%}
+                                                </div>
+                                            {%- endif -%}
+
+                                            {%- assign anchor_colour = "" -%}
+                                            {%- assign chevron_direction = "down" -%}
+                                            {%- assign hidden = "is-hidden" -%}
+                                            {%- if page.third_nav_title == collection_doc.third_nav_title -%}
+                                                {%- assign anchor_colour = "is-active" -%}
+                                                {%- assign chevron_direction = "up" -%}
+                                                {%- assign hidden = "" -%}
+                                            {%- endif -%}
+
+                                            <li class="third-level-nav-header">
+                                                <a class="third-level-nav-header {{ anchor_colour }}" aria-label="{{- collection_doc.third_nav_title -}}">
+                                                    {{- collection_doc.third_nav_title -}}<i class="sgds-icon sgds-icon-chevron-{{ chevron_direction }} is-pulled-right is-size-4" aria-hidden="true"></i>
+                                                </a>
+                                            </li>
+                                            <div class="third-level-nav-div {{ hidden }}">
+                                            {%- assign prev_third_nav_title = collection_doc.third_nav_title -%}
+                                            {%- assign in_third_nav = true -%}
+                                        {%- endif -%}
+
+                                        {%- assign anchor_colour = "" -%}
+                                        {%- if page.url == collection_doc.url -%}
+                                            {%- assign anchor_colour = "has-text-secondary has-text-weight-bold" -%}
+                                        {%- endif -%}
+
+                                        <li><a class="third-level-nav-item padding--top--none {{ anchor_colour }}" href="{{- collection_doc.url -}}">{{- collection_doc.title -}}</a></li>
+                                    {%- else -%}
+                                        {%- comment -%} If this is note a third level nav page {%- endcomment -%}
+                                        {%- if in_third_nav -%}
+                                            {%- comment -%} End previous third nav block {%- endcomment -%}
+                                            </div>
+                                            {%- assign in_third_nav = false -%}
+                                        {%- endif -%}
+
+                                        {%- assign anchor_colour = "" -%}
+                                        {%- if page.url == collection_doc.url -%}
+                                            {%- assign anchor_colour = "is-active" -%}
+                                        {%- endif -%}
+
+                                        <li>
+                                            <a class="{{ anchor_colour }}" href="{{- collection_doc.url -}}">{{- collection_doc.title -}}</a>
+                                        </li>
+                                    {%- endif -%}
+                                    {%- if forloop.last and in_third_nav -%}
+                                        </div>
+                                    {%- endif -%}
+                                {%- endfor -%}
+                            </ul>
+                        </aside>
+                    </div>
+                </div>
+                <div class="col is-8 is-offset-1-desktop is-12-touch print-content">
+                    {%- include datagov-search-display.html -%}
+                </div>
+            </div>
+        </div>
+    </section>
+    {%- for collection_doc in collection -%}
+        {%- if page.url == collection_doc.url -%}
+            {%- comment -%} If the page is the first in the list {%- endcomment -%}
+            {%- if forloop.first and collection[1] -%}
+                <section class="bp-section bottom-navigation">
+                    <div>
+                        <a href="{{- collection[1].url -}}" class="is-full is-right">
+                            <p class="has-text-weight-semibold">NEXT <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span></p>
+                            <p class="is-hidden-mobile">{{- collection[1].title -}}</p>
+                        </a>
+                    </div>
+                </section>
+
+            {%- comment -%} If the page is last in the list {%- endcomment -%}
+            {%- elsif forloop.last -%}
+                {%- assign prevIndex = forloop.index0 | minus: 1 -%}
+                {%- if prevIndex > 0 -%}
+                    <section class="bp-section bottom-navigation">
+                        <div>
+                            <a href="{{- collection[prevIndex].url -}}" class="is-full">
+                                <p class="has-text-weight-semibold"><span class="sgds-icon sgds-icon-arrow-left is-size-4"></span> PREVIOUS </p>
+                                <p class="is-hidden-mobile">{{- collection[prevIndex].title -}}</p>
+                            </a>
+                        </div>
+                    </section>
+                {%- endif -%}
+            {%- comment -%} For all other intermediate pages in the list {%- endcomment -%}
+            {%- else -%}
+                {%- assign prevIndex = forloop.index0 | minus: 1 -%}
+                {%- assign nextIndex = forloop.index0 | plus: 1 -%}
+
+                <section class="bp-section bottom-navigation">
+                    <div>
+                        <a href="{{- collection[prevIndex].url -}}" class="is-half is-left">
+                            <p class="has-text-weight-semibold"><span class="sgds-icon sgds-icon-arrow-left is-size-4"></span> PREVIOUS </p>
+                            <p class="is-hidden-mobile">{{- collection[prevIndex].title -}}</p>
+                        </a>
+                        <a href="{{- collection[nextIndex].url -}}" class="is-half is-right">
+                            <p class="has-text-weight-semibold">NEXT <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span></p>
+                            <p class="is-hidden-mobile">{{- collection[nextIndex].title -}}</p>
+                        </a>
+                    </div>
+                </section>
+            {%- endif -%}
+            {%- break -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- else -%}
+    {%- comment -%} If the page is standalone {%- endcomment -%}
+    <section class="bp-section">
+        <div class="bp-container padding--top--sm">
+            <div class="col">
+                {%- include datagov-search-display.html -%}
+            </div>
+        </div>
+    </section>
+{%- endif -%}


### PR DESCRIPTION
This PR adds an additional type of page for datagovsg v2. This is part of a greater effort to support datagov tables on the new database format provided - our existing functionality for full text search no longer works on new datasets, but we don't want to remove the existing functionality for websites, hence a new page layout has been created. Note that this layout is not supported on the CMS - this is purely a manual type of page introduced for rare specific sites which request it.

This PR aims to introduce third nav functionality to the pages in this format - it **does not** tackle the non-functional search mechanism, which will be handled in a future PR.

The new page format has been mostly made from a combination of the existing third-nav and datagov pages in the interest of time - I did not dig too deeply into the code because much of it is brittle and this is a very niche page type.

View of table in a third nav page:
<img width="1650" alt="Screenshot 2023-10-19 at 3 34 43 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/fc5ecce0-11e7-4c06-a12f-7dc62a5cbba8">

Test site with datagov embeds:
https://staging.duyfy15grdtiq.amplifyapp.com/datagovv2/thirdnav/
https://staging.duyfy15grdtiq.amplifyapp.com/unlinked/datagovv2/
