### PR TITLE
ci(percy): capture snapshot only during release

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - "next-gen"
-  push:
-    branches:
-      - "next-gen-develop"
-  workflow_dispatch:
 
 env:
   # The slug for the Isomer core team


### PR DESCRIPTION
Percy seems to have no concept of ancestor branches, which makes it difficult to identify visual changes on release. This change limits snapshots to only during release (aka PR to next-gen), so we can view all visual changes at a glance.