### PR TITLE
Feat/datagovsg v2 search

### DIFF
--- a/_application-guidelines/datagovsg-v2.md
+++ b/_application-guidelines/datagovsg-v2.md
@@ -1,0 +1,9 @@
+---
+title: "2006"
+permalink: /government-gazette/advertisements/2006/
+layout: datagovsg-v2-search
+datagovsg-id: d_837378d554e49c540129b5ced2073ac0
+description: ""
+third_nav_title: Advertisements
+default_field: Subject
+---

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -5,7 +5,7 @@
           <div id="database-search-container" class="col">
           <div class="field has-addons">
               <div class="control has-icons-left is-expanded datagov-search-border is-flex is-vh-centered">
-                  <input class="input is-fullwidth is-large has-border-grey-light is-size-6 pl-12" id="search-box-datagovsg" type="text" placeholder="What are you looking for?" name="query" autocomplete="off">
+                  <input class="input is-fullwidth is-large has-border-grey-light is-size-6 pl-12" style="height:3.25rem" id="search-box-datagovsg" type="text" placeholder="What are you looking for?" name="query" autocomplete="off">
                   <span class="is-large is-left">
                       <i class="sgds-icon sgds-icon-search is-size-4 search-bar"></i>
                   </span>
@@ -53,7 +53,7 @@
       <div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div>
   </div>
 </div>
-<div class="col is-full content horizontal-scroll datagovsg-table">
+<div class="col is-full content horizontal-scroll datagovsg-table p-0">
   {{- content -}}
 </div> 
 <div class="search pagination padding--bottom--xl">

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -11,6 +11,23 @@
                   </span>
 
               </div>
+              <span class="px-4" style="align-self:center;">
+                in
+              </span>
+              <div class="col is-one-quarter p-0 mr-3 is-hidden-touch">
+                <div class="filter-selector-div bp-dropdown is-full-height">
+                    <a class="bp-dropdown-button hero-dropdown is-centered padding--none is-full-height" aria-haspopup="true" aria-controls="hero-dropdown-menu">
+                    <div class="bp-dropdown-trigger">
+                        <span class="sgds-icon sgds-icon-chevron-down is-size-4 has-text-black" id="filter-arrow"></span>
+                        <input class="sgds-selector has-text-black pointer dropdown-input" id="field-selector-desktop" name="field" readonly ></input>
+                    </div>
+                    </a>
+                    <div class="bp-dropdown-menu has-text-left" id="hero-dropdown-menu" role="menu" >
+                      <div id="field-filter-desktop" class="bp-dropdown-content is-centered">
+                      </div>
+                    </div>
+                </div>
+              </div>
               <div class="control">
                   <button type="submit" class="bp-button is-secondary is-medium has-text-white search-button">SEARCH</button>
               </div>

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -11,7 +11,7 @@
                   </span>
 
               </div>
-              <span class="px-4" style="align-self:center;">
+              <span class="px-4 is-hidden-touch" style="align-self:center;">
                 in
               </span>
               <div class="col is-one-quarter p-0 mr-3 is-hidden-touch">
@@ -28,9 +28,24 @@
                     </div>
                 </div>
               </div>
-              <div class="control">
+              <div class="control is-hidden-touch">
                   <button type="submit" class="bp-button is-secondary is-medium has-text-white search-button">SEARCH</button>
               </div>
+          </div>
+          <div class="is-hidden-desktop is-flex" style="flex-direction: column;">
+            <span style="align-self:center;">
+              in
+            </span>
+            <div class="col is-fullwidth padding--top--lg is-hidden-desktop">
+              <div class="filter-selector-div is-hidden-desktop">
+                  <span class="sgds-icon sgds-icon-chevron-down is-size-4" id="filter-arrow"></span>
+                  <select id="field-filter-mobile" class="sgds-selector">
+                  </select>
+              </div>
+            </div>
+            <div class="p-3 is-full-width">
+              <button type="submit" class="bp-button is-secondary is-medium has-text-white search-button is-full-width" style="padding-left: 0 !important; padding-right: 0 !important;">SEARCH</button>
+            </div>
           </div>
           </div>
       </div>

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -4,8 +4,8 @@
       <div class="row">
           <div id="database-search-container" class="col">
           <div class="field has-addons">
-              <div class="control has-icons-left is-expanded datagov-search-border">
-                  <input class="input is-fullwidth is-large has-border-grey-light" id="search-box-datagovsg" type="text" placeholder="What are you looking for?" name="query" autocomplete="off">
+              <div class="control has-icons-left is-expanded datagov-search-border is-flex is-vh-centered">
+                  <input class="input is-fullwidth is-large has-border-grey-light is-size-6 pl-12" id="search-box-datagovsg" type="text" placeholder="What are you looking for?" name="query" autocomplete="off">
                   <span class="is-large is-left">
                       <i class="sgds-icon sgds-icon-search is-size-4 search-bar"></i>
                   </span>
@@ -19,11 +19,11 @@
                     <a class="bp-dropdown-button hero-dropdown is-centered padding--none is-full-height" aria-haspopup="true" aria-controls="hero-dropdown-menu">
                     <div class="bp-dropdown-trigger remove-border">
                         <span class="sgds-icon sgds-icon-chevron-down is-size-4 has-text-black" id="filter-arrow"></span>
-                        <input class="sgds-selector has-text-black pointer dropdown-input is-full-height" id="field-selector-desktop" name="field" readonly ></input>
+                        <input class="sgds-selector has-text-black pointer dropdown-input is-full-height is-size-6" id="field-selector-desktop" name="field" readonly ></input>
                     </div>
                     </a>
                     <div class="bp-dropdown-menu has-text-left" id="hero-dropdown-menu" role="menu" >
-                      <div id="field-filter-desktop" class="bp-dropdown-content is-centered">
+                      <div id="field-filter-desktop" class="bp-dropdown-content is-centered is-flex" style="flex-direction: column; gap: 0.5rem;">
                       </div>
                     </div>
                 </div>

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -4,7 +4,7 @@
       <div class="row">
           <div id="database-search-container" class="col">
           <div class="field has-addons">
-              <div class="control has-icons-left is-expanded">
+              <div class="control has-icons-left is-expanded datagov-search-border">
                   <input class="input is-fullwidth is-large has-border-grey-light" id="search-box-datagovsg" type="text" placeholder="What are you looking for?" name="query" autocomplete="off">
                   <span class="is-large is-left">
                       <i class="sgds-icon sgds-icon-search is-size-4 search-bar"></i>
@@ -15,11 +15,11 @@
                 in
               </span>
               <div class="col is-one-quarter p-0 mr-3 is-hidden-touch">
-                <div class="filter-selector-div bp-dropdown is-full-height">
+                <div class="bp-dropdown is-full-height">
                     <a class="bp-dropdown-button hero-dropdown is-centered padding--none is-full-height" aria-haspopup="true" aria-controls="hero-dropdown-menu">
-                    <div class="bp-dropdown-trigger">
+                    <div class="bp-dropdown-trigger remove-border">
                         <span class="sgds-icon sgds-icon-chevron-down is-size-4 has-text-black" id="filter-arrow"></span>
-                        <input class="sgds-selector has-text-black pointer dropdown-input" id="field-selector-desktop" name="field" readonly ></input>
+                        <input class="sgds-selector has-text-black pointer dropdown-input is-full-height" id="field-selector-desktop" name="field" readonly ></input>
                     </div>
                     </a>
                     <div class="bp-dropdown-menu has-text-left" id="hero-dropdown-menu" role="menu" >
@@ -33,18 +33,15 @@
               </div>
           </div>
           <div class="is-hidden-desktop is-flex" style="flex-direction: column;">
-            <span style="align-self:center;">
-              in
-            </span>
-            <div class="col is-fullwidth padding--top--lg is-hidden-desktop">
-              <div class="filter-selector-div is-hidden-desktop">
+            <div class="col is-fullwidth is-hidden-desktop is-flex">
+              <div class="is-hidden-desktop is-full-width is-full-height datagov-search-border">
                   <span class="sgds-icon sgds-icon-chevron-down is-size-4" id="filter-arrow"></span>
-                  <select id="field-filter-mobile" class="sgds-selector">
+                  <select id="field-filter-mobile" class="sgds-selector dropdown-input">
                   </select>
               </div>
-            </div>
-            <div class="p-3 is-full-width">
-              <button type="submit" class="bp-button is-secondary is-medium has-text-white search-button is-full-width" style="padding-left: 0 !important; padding-right: 0 !important;">SEARCH</button>
+              <div class="px-3">
+                <button type="submit" class="bp-button is-secondary is-medium has-text-white search-button">SEARCH</button>
+              </div>
             </div>
           </div>
           </div>

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -5,21 +5,21 @@
           <div id="database-search-container" class="col">
           <div class="field has-addons">
               <div class="control has-icons-left is-expanded datagov-search-border is-flex is-vh-centered">
-                  <input class="input is-fullwidth is-large has-border-grey-light is-size-6 pl-12" style="height:3.25rem" id="search-box-datagovsg" type="text" placeholder="What are you looking for?" name="query" autocomplete="off">
+                  <input class="input is-fullwidth is-large has-border-grey-light is-size-5 pl-12" style="height:3.25rem" id="search-box-datagovsg" type="text" placeholder="What are you looking for?" name="query" autocomplete="off">
                   <span class="is-large is-left">
-                      <i class="sgds-icon sgds-icon-search is-size-4 search-bar"></i>
+                      <i class="sgds-icon sgds-icon-search is-size-5 search-bar"></i>
                   </span>
 
               </div>
-              <span class="px-4 is-hidden-touch" style="align-self:center;">
+              <span class="px-4 is-hidden-touch is-size-5" style="align-self:center;">
                 in
               </span>
               <div class="col is-one-quarter p-0 mr-3 is-hidden-touch">
                 <div class="bp-dropdown is-full-height">
                     <a class="bp-dropdown-button hero-dropdown is-centered padding--none is-full-height" aria-haspopup="true" aria-controls="hero-dropdown-menu">
                     <div class="bp-dropdown-trigger remove-border">
-                        <span class="sgds-icon sgds-icon-chevron-down is-size-4 has-text-black" id="filter-arrow"></span>
-                        <input class="sgds-selector has-text-black pointer dropdown-input is-full-height is-size-6" id="field-selector-desktop" name="field" readonly ></input>
+                        <span class="sgds-icon sgds-icon-chevron-down is-size-5 has-text-black" id="filter-arrow"></span>
+                        <input class="sgds-selector has-text-black pointer dropdown-input is-full-height is-size-5" id="field-selector-desktop" name="field" readonly ></input>
                     </div>
                     </a>
                     <div class="bp-dropdown-menu has-text-left" id="hero-dropdown-menu" role="menu" >

--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -50,6 +50,7 @@
 
 {%- if page.layout == 'datagovsg-v2-search' -%}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.11/purify.min.js" integrity="sha384-ELH09WGRUcBpRT6iHTekFB2YBCT9kFMsKG4Y9LUAevHjihu8Otri8Sm01QgXOTht" crossorigin="anonymous"></script>
+<script>var defaultField = "{{ page.default_field }}";</script>
 <script src="{{- "/assets/js/pagination-util.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/search.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/datagovsg-search.js" | relative_url -}}" crossorigin="anonymous"></script>

--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -43,6 +43,7 @@
 
 {%- if page.layout == 'datagovsg-search' -%}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.11/purify.min.js" integrity="sha384-ELH09WGRUcBpRT6iHTekFB2YBCT9kFMsKG4Y9LUAevHjihu8Otri8Sm01QgXOTht" crossorigin="anonymous"></script>
+<script>var defaultField = "";</script>
 <script src="{{- "/assets/js/pagination-util.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/search.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/datagovsg-search.js" | relative_url -}}" crossorigin="anonymous"></script>

--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -43,7 +43,7 @@
 
 {%- if page.layout == 'datagovsg-search' -%}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.11/purify.min.js" integrity="sha384-ELH09WGRUcBpRT6iHTekFB2YBCT9kFMsKG4Y9LUAevHjihu8Otri8Sm01QgXOTht" crossorigin="anonymous"></script>
-<script>var defaultField = "";</script>
+<div id="default-field" data-title=""></div>
 <script src="{{- "/assets/js/pagination-util.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/search.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/datagovsg-search.js" | relative_url -}}" crossorigin="anonymous"></script>
@@ -51,7 +51,7 @@
 
 {%- if page.layout == 'datagovsg-v2-search' -%}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.11/purify.min.js" integrity="sha384-ELH09WGRUcBpRT6iHTekFB2YBCT9kFMsKG4Y9LUAevHjihu8Otri8Sm01QgXOTht" crossorigin="anonymous"></script>
-<script>var defaultField = "{{ page.default_field }}";</script>
+<div id="default-field" data-title="{{ page.default_field }}"></div>
 <script src="{{- "/assets/js/pagination-util.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/search.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/datagovsg-search.js" | relative_url -}}" crossorigin="anonymous"></script>

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -11578,5 +11578,8 @@ h6 center {
 .remove-after:after {
   content: "" !important
 }
+.dropdown-input:focus {
+  outline: none;
+}
 
 /*# sourceMappingURL=blueprint.css.map */

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -11581,5 +11581,14 @@ h6 center {
 .dropdown-input:focus {
   outline: none;
 }
+.datagov-search-border {
+  border-bottom: 1px solid #D6D6D6;
+}
+.remove-border {
+  border: none;
+}
+.datagov-focus-border:focus {
+  border: 2px solid #000AFF;
+}
 
 /*# sourceMappingURL=blueprint.css.map */

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -137,6 +137,7 @@ function remove(array, elements) {
 function displaySearchFilterDropdown(fields, startingField) {
   var fieldFilterDesktop = document.getElementById('field-filter-desktop');
   var fieldFilterMobile = document.getElementById('field-filter-mobile');
+  if (!fieldFilterDesktop || !fieldFilterMobile) return
 
   for (let field of fields) {
     // Creating the select element for mobile view

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -75,13 +75,13 @@ function databaseSearch(searchTerm, index, searchField) {
     fieldArray = remove(data.result.fields, ["_id", "_full_count", "rank", `rank ${searchField}`]);
     pageResults = pageResults.concat(splitPages(data.result.records, RESULTS_PER_PAGE));
     datagovsgTotal = data.result.total;
+    if (!hasPopulatedFields) {
+      displaySearchFilterDropdown(fieldArray.map(item => item.id), searchField || defaultField);
+      hasPopulatedFields = true
+    }
     displayTable(pageResults[currentPageIndex], fieldArray);
     if (!pageResults || pageResults.length <= 1) return;
     displayPagination(index);
-    if (!hasPopulatedFields) {
-      displaySearchFilterDropdown(fieldArray.map(item => item.id), defaultField);
-      hasPopulatedFields = true
-    }
   })
     .fail(function () { // Displays no results if the AJAX call fails
       document.getElementById("loading-spinner").style.display = 'none';
@@ -134,11 +134,17 @@ function remove(array, elements) {
   });
 }
 
-function displaySearchFilterDropdown(fields, defaultField) {
+function displaySearchFilterDropdown(fields, startingField) {
   var fieldFilterDesktop = document.getElementById('field-filter-desktop');
+  var fieldFilterMobile = document.getElementById('field-filter-mobile');
 
   for (let field of fields) {
-    const startingField = searchField || defaultField
+    // Creating the select element for mobile view
+    var option = document.createElement("option");
+    option.value = field;
+    option.text = field;
+    if (field === startingField) option.selected = true
+    fieldFilterMobile.appendChild(option);
 
     // Creating the a tags for desktop view
     var a_element = document.createElement("a");

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -137,7 +137,6 @@ function remove(array, elements) {
 function displaySearchFilterDropdown(fields, startingField) {
   var fieldFilterDesktop = document.getElementById('field-filter-desktop');
   var fieldFilterMobile = document.getElementById('field-filter-mobile');
-  if (!fieldFilterDesktop || !fieldFilterMobile) return
 
   for (let field of fields) {
     // Creating the select element for mobile view

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -152,7 +152,7 @@ function displaySearchFilterDropdown(fields, startingField) {
     // Creating the a tags for desktop view
     var a_element = document.createElement("a");
     a_element.id = field;
-    a_element.classList.add("bp-dropdown-item", "padding--top--sm", "padding--bottom--none");
+    a_element.classList.add("bp-dropdown-item", "py-0");
     a_element.onclick = function () {
       return function () {
         var filterDropdownDesktop = document.getElementById('field-selector-desktop');
@@ -166,7 +166,8 @@ function displaySearchFilterDropdown(fields, startingField) {
 
     fieldFilterDesktop.appendChild(a_element);
     var p_element = document.createElement("p");
-    p_element.innerHTML = field;
+    p_element.innerHTML = field.replace("_", " ");
+    p_element.classList.add("is-size-6")
     a_element.appendChild(p_element);
   }
 }

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -9,6 +9,8 @@ var MAX_ADJACENT_MOBILE_PAGE_BTNS = 1;
 var pageResults = [];
 var fieldArray = void 0;
 var startIndex = 0;
+const defaultFieldElement = document.getElementById('default-field');
+const defaultField = defaultFieldElement ? defaultFieldElement.getAttribute('data-title') : "";
 
 var datagovsgOffset = 0;
 // The datagovsg API only retrieves 100 rows at a go.
@@ -75,8 +77,9 @@ function databaseSearch(searchTerm, index, searchField) {
     fieldArray = remove(data.result.fields, ["_id", "_full_count", "rank", `rank ${searchField}`]);
     pageResults = pageResults.concat(splitPages(data.result.records, RESULTS_PER_PAGE));
     datagovsgTotal = data.result.total;
-    if (!hasPopulatedFields) {
-      displaySearchFilterDropdown(fieldArray.map(item => item.id), searchField || defaultField);
+    const possibleSearchField = searchField || defaultField
+    if (!hasPopulatedFields && possibleSearchField) {
+      displaySearchFilterDropdown(fieldArray.map(item => item.id), possibleSearchField);
       hasPopulatedFields = true
     }
     displayTable(pageResults[currentPageIndex], fieldArray);


### PR DESCRIPTION
Resolves IS-647.

This PR adds search functionality for datagovsg-v2 pages. Pages which use the updated type of data model on datagovsg no longer support full text search, so the existing search functionality of v1 pages doesn't work. This PR serves to replace that functionality with search for a single field, while not modifying the existing behaviour of existing pages.

[Figma](https://www.figma.com/file/bux8xvVXS6FOXP6G8clwgA/Explorations-%2F-Archives-%2F-Brainstorming?type=design&node-id=1755-1587&mode=design)

Old page:
https://staging.duyfy15grdtiq.amplifyapp.com/data-gov-sg/

Unlinked new page:
https://staging.duyfy15grdtiq.amplifyapp.com/unlinked/datagovv2/

third nav new page:
https://staging.duyfy15grdtiq.amplifyapp.com/datagovv2/thirdnav/

Tests:

- [ ] Search functionality should work correctly for both old and new pages
- [ ] v2 pages should start with their specified field in the search bar by default
- [ ] v2 pages should have the search query and search field reflect the user input upon submission