### PR TITLE
chore: add specific css to handle pdfs in dgsv2 table

### DIFF
--- a/_application-guidelines/datagovsg-v2.md
+++ b/_application-guidelines/datagovsg-v2.md
@@ -6,4 +6,5 @@ datagovsg-id: d_837378d554e49c540129b5ced2073ac0
 description: ""
 third_nav_title: Advertisements
 default_field: Subject
+infotext: true
 ---

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -69,10 +69,15 @@
   {{- content -}}
 </div> 
 <div class="search pagination padding--bottom--xl">
-  <span class="sgds-icon sgds-icon-arrow-left is-size-4"></span>
+  <span class="bx bx-chevrons-left is-size-4 pointer" aria-label="Skip to start"></span>
+  <div class="px-1 is-hidden-mobile"></div>
+  <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only pointer" aria-label="Previous page"></span>
   {%- comment -%} To insert page selectors {%- endcomment -%}
-  <div id="paginator-pages"></div>
-  <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span>
+  <div id="paginator-pages" class="is-hidden-mobile"></div>
+  <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
+  <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only pointer" aria-label="Next page"></span>
+  <div class="px-1 is-hidden-mobile"></div>
+  <span class="bx bx-chevrons-right is-size-4 pointer" aria-label="Skip to end"></span>
 </div>
 
 

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -1,5 +1,20 @@
 <!-- Search bar display -->
 <div class="pb-12">
+  {%- if page.infotext and page.collection and page.collection != "posts" -%}
+    <div class="subtitle-1 pb-1 datagov-v2-browsing">You are browsing</div>
+    <div class="pb-8 subtitle-1">
+      
+      {{ page.collection | replace: "-", " " | replace: "_", " " | capitalize}}
+      {%- if page.third_nav_title -%}
+        <i class="sgds-icon sgds-icon-chevron-right is-size-5 px-1" aria-hidden="true"></i>
+        {{- page.third_nav_title -}}
+      {%- endif -%}
+      {%- if page.title -%}
+        <i class="sgds-icon sgds-icon-chevron-right is-size-5 px-1" aria-hidden="true"></i>
+        {{- page.title -}}
+      {%- endif -%}
+    </div>
+  {%- endif -%}
   <form action="{{site.baseurl}}{{page.url}}" method="get">
       <div class="row">
           <div id="database-search-container" class="col">
@@ -11,10 +26,7 @@
                   </span>
 
               </div>
-              <span class="px-4 is-hidden-touch is-size-5" style="align-self:center;">
-                in
-              </span>
-              <div class="col is-one-quarter p-0 mr-3 is-hidden-touch">
+              <div class="col is-one-quarter p-0 pl-4 mr-3 is-hidden-touch">
                 <div class="bp-dropdown is-full-height">
                     <a class="bp-dropdown-button hero-dropdown is-centered padding--none is-full-height" aria-haspopup="true" aria-controls="hero-dropdown-menu">
                     <div class="bp-dropdown-trigger remove-border">
@@ -33,13 +45,13 @@
               </div>
           </div>
           <div class="is-hidden-desktop is-flex" style="flex-direction: column;">
-            <div class="col is-fullwidth is-hidden-desktop is-flex">
+            <div class="col is-fullwidth is-hidden-desktop is-flex px-0">
               <div class="is-hidden-desktop is-full-width is-full-height datagov-search-border">
                   <span class="sgds-icon sgds-icon-chevron-down is-size-4" id="filter-arrow"></span>
                   <select id="field-filter-mobile" class="sgds-selector dropdown-input">
                   </select>
               </div>
-              <div class="px-3">
+              <div class="pl-3">
                 <button type="submit" class="bp-button is-secondary is-medium has-text-white search-button">SEARCH</button>
               </div>
             </div>

--- a/_layouts/datagovsg-search.html
+++ b/_layouts/datagovsg-search.html
@@ -53,11 +53,16 @@ layout: skeleton
 </section>
 
 
-<div class="search pagination padding--bottom--xl">
-    <span class="sgds-icon sgds-icon-arrow-left is-size-4"></span>
+<div class="px-6 search pagination padding--bottom--xl">
+    <span class="bx bx-chevrons-left is-size-4"></span>
+    <div class="px-1 is-hidden-mobile"></div>
+    <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}
-    <div id="paginator-pages"></div>
-    <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span>
+    <div id="paginator-pages" class="is-hidden-mobile"></div>
+    <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
+    <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+    <div class="px-1 is-hidden-mobile"></div>
+    <span class="bx bx-chevrons-right is-size-4"></span>
 </div>
 
 <span style="display: none;" id="resourceId">{{- page.datagovsg-id -}}</span>

--- a/_layouts/events-listing.html
+++ b/_layouts/events-listing.html
@@ -130,9 +130,14 @@ layout: skeleton
     </div>
 </section>
 
-<div class="search pagination padding--bottom--xl">
-    <span class="sgds-icon sgds-icon-arrow-left is-size-4"></span>
+<div class="px-6 search pagination padding--bottom--xl">
+    <span class="bx bx-chevrons-left is-size-4"></span>
+    <div class="px-1 is-hidden-mobile"></div>
+    <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}
-    <div id="paginator-pages"></div>
-    <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span>
+    <div id="paginator-pages" class="is-hidden-mobile"></div>
+    <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
+    <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+    <div class="px-1 is-hidden-mobile"></div>
+    <span class="bx bx-chevrons-right is-size-4"></span>
 </div>

--- a/_layouts/resources-alt.html
+++ b/_layouts/resources-alt.html
@@ -102,9 +102,14 @@ layout: skeleton
     </div>
 </section>
 
-<div class="search pagination padding--bottom--xl">
-    <span class="sgds-icon sgds-icon-arrow-left is-size-4"></span>
+<div class="px-6 search pagination padding--bottom--xl">
+    <span class="bx bx-chevrons-left is-size-4"></span>
+    <div class="px-1 is-hidden-mobile"></div>
+    <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}
-    <div id="paginator-pages"></div>
-    <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span>
+    <div id="paginator-pages" class="is-hidden-mobile"></div>
+    <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
+    <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+    <div class="px-1 is-hidden-mobile"></div>
+    <span class="bx bx-chevrons-right is-size-4"></span>
 </div>

--- a/_layouts/resources.html
+++ b/_layouts/resources.html
@@ -89,9 +89,14 @@ layout: skeleton
 </section>
 
 
-<div class="search pagination padding--bottom--xl">
-    <span class="sgds-icon sgds-icon-arrow-left is-size-4"></span>
+<div class="px-6 search pagination padding--bottom--xl">
+    <span class="bx bx-chevrons-left is-size-4"></span>
+    <div class="px-1 is-hidden-mobile"></div>
+    <span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
     {%- comment -%} To insert page selectors {%- endcomment -%}
-    <div id="paginator-pages"></div>
-    <span class="sgds-icon sgds-icon-arrow-right is-size-4"></span>
+    <div id="paginator-pages" class="is-hidden-mobile"></div>
+    <div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
+    <span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+    <div class="px-1 is-hidden-mobile"></div>
+    <span class="bx bx-chevrons-right is-size-4"></span>
 </div>

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -59,9 +59,14 @@ layout: skeleton
     </div>
 </section>
 
-<div class="search pagination padding--bottom--xl">
-	<span class="sgds-icon sgds-icon-arrow-left is-size-4"></span>
+<div class="px-6 search pagination padding--bottom--xl">
+	<span class="bx bx-chevrons-left is-size-4"></span>
+	<div class="px-1 is-hidden-mobile"></div>
+	<span class="sgds-icon sgds-icon-arrow-left is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
 	{%- comment -%} To insert page selectors {%- endcomment -%}
-	<div id="paginator-pages"></div>
-	<span class="sgds-icon sgds-icon-arrow-right is-size-4"></span>
+	<div id="paginator-pages" class="is-hidden-mobile"></div>
+	<div id="paginator-pages-mobile" class="is-hidden-desktop is-hidden-tablet-only is-full-width"></div>
+	<span class="sgds-icon sgds-icon-arrow-right is-size-4 is-hidden-desktop is-hidden-tablet-only"></span>
+	<div class="px-1 is-hidden-mobile"></div>
+	<span class="bx bx-chevrons-right is-size-4"></span>
 </div>

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -11590,5 +11590,14 @@ h6 center {
 .datagov-focus-border:focus {
   border: 2px solid #000AFF;
 }
-
+.datagov-search-element a {
+  /* Specific to pdfs in the datagov table view */
+  display: inline-block;
+  /* Overwrite existing margin-bottom that all a elements have */
+  margin-bottom: 0;
+}
+.datagov-search-element a[href$=".pdf"]:before {
+  /* Specific to pdfs to center icon in the datagov table view */
+  display: flex;
+}
 /*# sourceMappingURL=blueprint.css.map */

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -11601,3 +11601,6 @@ h6 center {
   display: flex;
 }
 /*# sourceMappingURL=blueprint.css.map */
+.datagov-v2-browsing {
+  color: #666C7A;
+}

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -10891,6 +10891,7 @@ h6 center {
   text-decoration: none;
 }
 .pagination span {
+  flex: 0 0 3rem;
   width: 3rem;
   line-height: 3rem;
   border: 1px solid #d6d6d6;
@@ -10915,7 +10916,6 @@ h6 center {
   border: 1px solid #d6d6d6;
 }
 .pagination span.sgds-icon {
-  padding: 0 3rem 0 2rem;
   margin: 0 0.75rem;
 }
 .pagination .selected-page {
@@ -11585,7 +11585,7 @@ h6 center {
   border-bottom: 1px solid #D6D6D6;
 }
 .remove-border {
-  border: none;
+  border: none !important;
 }
 .datagov-focus-border:focus {
   border: 2px solid #000AFF;

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -111,7 +111,7 @@ function displayTable(chunk, fields) {
     resultString += '<tr>';
     for (var fieldIndex in fields) {
       var _fieldId = fields[fieldIndex].id;
-      resultString += '<td><h6 class=\"margin--none\">' + chunk[chunkIndex][_fieldId] + '</h6></td>';
+      resultString += '<td><h6 class=\"margin--none datagov-search-element\">' + chunk[chunkIndex][_fieldId] + '</h6></td>';
     }
     resultString += '</tr>';
   }

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -3,7 +3,8 @@ layout: blank
 ---
 'use strict';
 
-var RESULTS_PER_PAGE = 10;
+const PAGINATION_DISPLAY_RESULTS_PER_PAGE = 10; // Must be smaller than size of datagov pagination (100)
+const DATAGOV_API_RESULTS_PER_PAGE = 100; // Fixed by datagov
 var MAX_ADJACENT_PAGE_BTNS = 2;
 var MAX_ADJACENT_MOBILE_PAGE_BTNS = 1;
 var pageResults = [];
@@ -51,11 +52,21 @@ function getQueryVariable(variable) {
   }
 }
 
-function databaseSearch(searchTerm, index, searchField) {
+function getOffset(pageIndex) {
+  // Retrieves the offset required for the first item in the page
+  // pageIndex is 0-indexed
+  const firstElemIndex = pageIndex * PAGINATION_DISPLAY_RESULTS_PER_PAGE
+  const offsetRequired = Math.floor(firstElemIndex / DATAGOV_API_RESULTS_PER_PAGE) * DATAGOV_API_RESULTS_PER_PAGE
+  return offsetRequired
+}
+
+function databaseSearch(searchTerm, index, callback) {
+  const isFirstRender = pageResults.length === 0
   const resourceId = document.getElementById("resourceId").innerHTML;
+  const offset = getOffset(index)
   var data = {
     resource_id: resourceId, // the resource id
-    offset: datagovsgOffset
+    offset
   };
 
   if (searchTerm !== '') {
@@ -66,25 +77,47 @@ function databaseSearch(searchTerm, index, searchField) {
   var request = $.ajax({
     url: 'https://data.gov.sg/api/action/datastore_search',
     data: data,
-    dataType: 'json'
+    dataType: 'json',
+    success: callback
   });
 
   request.done(function (data) {
-    document.getElementById("loading-spinner").style.display = 'none';
-    hideAllPostsAndPagination();
+    datagovsgTotal = data.result.total;
+    if (isFirstRender) {
+      pageResults = Array(Math.ceil(datagovsgTotal / PAGINATION_DISPLAY_RESULTS_PER_PAGE)).fill(null);
+    } else {
+      // Delay loading spinner disappearing for first render
+      document.getElementById("loading-spinner").style.display = 'none';
+    }
 
     // The fieldArray is the array containing the field names in the data.gov.sg table
-    fieldArray = remove(data.result.fields, ["_id", "_full_count", "rank", `rank ${searchField}`]);
-    pageResults = pageResults.concat(splitPages(data.result.records, RESULTS_PER_PAGE));
-    datagovsgTotal = data.result.total;
+    const removableFields = ["_id", "_full_count", "rank", `rank ${searchField}`]
+    fieldArray = remove(data.result.fields, removableFields);
+    const pageResultArray = splitPages(data.result.records, PAGINATION_DISPLAY_RESULTS_PER_PAGE)
+    const startingPage = offset / PAGINATION_DISPLAY_RESULTS_PER_PAGE
     const possibleSearchField = searchField || defaultField
     if (!hasPopulatedFields && possibleSearchField) {
       displaySearchFilterDropdown(fieldArray.map(item => item.id), possibleSearchField);
       hasPopulatedFields = true
     }
-    displayTable(pageResults[currentPageIndex], fieldArray);
-    if (!pageResults || pageResults.length <= 1) return;
-    displayPagination(index);
+    pageResultArray.forEach((pageData, idx) => {
+      pageResults[startingPage + idx] = pageData
+    })
+    if (isFirstRender) {
+      // Also preload the last set of pages if applicable
+      const finalPage = Math.ceil(datagovsgTotal / PAGINATION_DISPLAY_RESULTS_PER_PAGE) - 1
+      const renderDisplay = () => {
+        document.getElementById("loading-spinner").style.display = 'none';
+        displayTable(pageResults[currentPageIndex], fieldArray);
+        if (pageResults.length === 0) return;
+        displayPagination(index);
+      }
+      if (getOffset(finalPage) !== 0) {
+        databaseSearch(searchTerm, finalPage, renderDisplay)
+      } else {
+        renderDisplay()
+      }
+    }
   })
     .fail(function () { // Displays no results if the AJAX call fails
       document.getElementById("loading-spinner").style.display = 'none';
@@ -176,8 +209,10 @@ function displaySearchFilterDropdown(fields, startingField) {
 function displayPagination(index) {
   document.querySelector(".pagination").style.display = "flex";
   var pagination = document.getElementById('paginator-pages');
+  const paginationMobile = document.getElementById('paginator-pages-mobile')
+  const totalPages = Math.ceil(datagovsgTotal / PAGINATION_DISPLAY_RESULTS_PER_PAGE)
 
-  for (var i = 0; i < pageResults.length; i++) {
+  for (var i = 0; i < totalPages; i++) {
     var ele = document.createElement("span");
     var text = document.createTextNode(i + 1);
     ele.appendChild(text);
@@ -190,6 +225,16 @@ function displayPagination(index) {
     pagination.appendChild(ele);
   }
 
+  // Create page display for mobile
+  if (paginationMobile) {
+    const ele = document.createElement("span")
+    const text = document.createTextNode(`Page ${index}`)
+    ele.classList.add("is-full-height", "is-full-width", "remove-border")
+    ele.style.width = "100%"
+    ele.appendChild(text)
+    paginationMobile.appendChild(ele)
+  }
+  
   // Initialise selected page and nav arrows
   setCurrentPage(pagination.childNodes[index]);
   displayNavArrows(currentPageIndex);
@@ -201,25 +246,24 @@ function changePage(curr, index) {
     datagovsgOffset += 100;
     databaseSearch(searchTerm, index, searchField);
   }
+  // Always also look 5 pages ahead and behind
+  const forwardIndex = index + 5
+  const backwardIndex = index - 5
+  if (shouldCallAPI(forwardIndex)) {
+    databaseSearch(searchTerm, forwardIndex);
+  }
+  if (shouldCallAPI(backwardIndex)) {
+    databaseSearch(searchTerm, backwardIndex);
+  }
 
   changePageUtil(curr, index);
   displayTable(pageResults[currentPageIndex], fieldArray);
 }
 
-// Evaluates to true if we should call the datagovsg API for the 
-// next 100 rows of data
+// Evaluates to true if we should call the datagovsg API
 function shouldCallAPI(index) {
-  // Checks to make sure that the last digit of the page number is greater than 5.
-  // i.e. we should call the API for the next 100 rows if the user is currently at 
-  // page number 26.
-  // Note: the index starts from 0, so a page index of 14 corresponds to a page number of 15.
-  if (index % 10 < 4) return false;
-
-  // Makes sure that there is more data to be retrieved from the API.
-  if (datagovsgOffset + 100 > datagovsgTotal) return false;
-
-  // Makes sure that we haven't already called the API for the next 100 rows.
-  if (index * RESULTS_PER_PAGE < datagovsgOffset) return false;
-
-  return true;
+  if (pageResults[index] !== null) return false
+  if (index < 0) return false
+  if (index > datagovsgTotal / PAGINATION_DISPLAY_RESULTS_PER_PAGE) return false
+  return true
 }

--- a/assets/js/pagination-util.js
+++ b/assets/js/pagination-util.js
@@ -20,6 +20,17 @@ function displayPagination() {
     _loop(i);
   }
 
+  // Create page display for mobile
+  const paginationMobile = document.getElementById('paginator-pages-mobile')
+  if (paginationMobile) {
+    const ele = document.createElement("span")
+    const text = document.createTextNode(`Page`)
+    ele.classList.add("is-full-height", "is-full-width", "remove-border")
+    ele.style.width = "100%"
+    ele.appendChild(text)
+    paginationMobile.appendChild(ele)
+  }
+
   // Initialise selected page and nav arrows
   setCurrentPage(pagination.firstElementChild);
   displayNavArrows(currentPageIndex);
@@ -28,15 +39,25 @@ function displayPagination() {
 
 // Set click handlers for nav arrows
 function setNavArrowHandlers() {
+  var farLeft = document.querySelector(".pagination .bx.bx-chevrons-left");
   var left = document.querySelector(".pagination .sgds-icon.sgds-icon-arrow-left");
+  var farRight = document.querySelector(".pagination .bx.bx-chevrons-right");
   var right = document.querySelector(".pagination .sgds-icon.sgds-icon-arrow-right");
   var sel = document.querySelector("#paginator-pages .selected-page");
+  var pagination = document.getElementById('paginator-pages');
 
+  if (farLeft) farLeft.onclick = function (e) {
+    changePage(pagination.firstElementChild, 0);
+  };
   left.onclick = function (e) {
     var sel = document.querySelector("#paginator-pages .selected-page");
     changePage(sel.previousElementSibling, currentPageIndex - 1);
   };
 
+  if (farRight) farRight.onclick = function (e) {
+    const totalPages = pagination.children[pagination.children.length - 1].textContent
+    changePage(pagination.lastElementChild, totalPages - 1);
+  };
   right.onclick = function (e) {
     var sel = document.querySelector("#paginator-pages .selected-page");
     changePage(sel.nextElementSibling, currentPageIndex + 1);
@@ -54,17 +75,23 @@ function changePageUtil(curr, index) {
 }
 
 function displayNavArrows(i) {
+  var farLeft = document.querySelector(".pagination .bx.bx-chevrons-left");
   var left = document.querySelector(".pagination .sgds-icon.sgds-icon-arrow-left");
+  var farRight = document.querySelector(".pagination .bx.bx-chevrons-right");
   var right = document.querySelector(".pagination .sgds-icon.sgds-icon-arrow-right");
 
   if (i === 0) {
+    if (farLeft) farLeft.classList.add("sgds-icon-disabled");
     left.classList.add("sgds-icon-disabled");
   } else {
+    if (farLeft) farLeft.classList.remove("sgds-icon-disabled");
     left.classList.remove("sgds-icon-disabled");
   }
   if (i === pageResults.length - 1) {
+    if (farRight) farRight.classList.add("sgds-icon-disabled");
     right.classList.add("sgds-icon-disabled");
   } else {
+    if (farRight) farRight.classList.remove("sgds-icon-disabled");
     right.classList.remove("sgds-icon-disabled");
   }
 }
@@ -112,6 +139,10 @@ function setCurrentPage(ele) {
     if (pages[currentPageIndex - _i]) {
       pages[currentPageIndex - _i].classList.remove("is-hidden-mobile");
     }
+  }
+  const mobilePage = document.getElementById("paginator-pages-mobile")
+  if (mobilePage) {
+    mobilePage.children[0].textContent = `Page ${currentPageIndex + 1}`
   }
 }
 


### PR DESCRIPTION
## Problem

This PR adds css to allow the pdfs to display more nicely for dgs v2 tables. The css added is very specific to the data format that e-gazette is using (each data entry is a `<a>` tag wrapping the file) - it should not affect anything else. Note that this also means that modification of the data layout stored will also cause this styling to break.

Resolves IS-767

Before:
<img width="984" alt="Screenshot 2023-11-14 at 2 45 11 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/cdac5780-899a-4842-81db-60e787218126">

After:
<img width="911" alt="Screenshot 2023-11-14 at 2 45 27 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/62c19897-7b81-4250-acb0-3107b6d8879c">

Live site:
https://staging.duyfy15grdtiq.amplifyapp.com/datagovv2/thirdnav/?query=advertisement&field=Subject
