### PR TITLE
Feat/add text at top of screen for dgs search

### DIFF
--- a/_application-guidelines/datagovsg-v2.md
+++ b/_application-guidelines/datagovsg-v2.md
@@ -6,4 +6,5 @@ datagovsg-id: d_837378d554e49c540129b5ced2073ac0
 description: ""
 third_nav_title: Advertisements
 default_field: Subject
+infotext: true
 ---

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -1,15 +1,16 @@
 <!-- Search bar display -->
 <div class="pb-12">
   {%- if page.infotext and page.collection and page.collection != "posts" -%}
-    <div class="pb-8 subtitle-1">
-      You are searching for
+    <div class="subtitle-1" style="color: #939393">You are browsing</div>
+    <div class="pb-8 subtitle-1 has-text-weight-semibold">
+      
       {{ page.collection | replace: "-", " " | replace: "_", " " | upcase}}
       {%- if page.third_nav_title -%}
-        <i class="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true"></i>
+        <i class="sgds-icon sgds-icon-chevron-right is-size-5 px-1" aria-hidden="true"></i>
         {{- page.third_nav_title -}}
       {%- endif -%}
       {%- if page.title -%}
-        <i class="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true"></i>
+        <i class="sgds-icon sgds-icon-chevron-right is-size-5 px-1" aria-hidden="true"></i>
         {{- page.title -}}
       {%- endif -%}
     </div>

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -1,5 +1,19 @@
 <!-- Search bar display -->
 <div class="pb-12">
+  {%- if page.infotext and page.collection and page.collection != "posts" -%}
+    <div class="pb-8 subtitle-1">
+      You are searching for
+      {{ page.collection | replace: "-", " " | replace: "_", " " | upcase}}
+      {%- if page.third_nav_title -%}
+        <i class="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true"></i>
+        {{- page.third_nav_title -}}
+      {%- endif -%}
+      {%- if page.title -%}
+        <i class="sgds-icon sgds-icon-arrow-right is-size-4" aria-hidden="true"></i>
+        {{- page.title -}}
+      {%- endif -%}
+    </div>
+  {%- endif -%}
   <form action="{{site.baseurl}}{{page.url}}" method="get">
       <div class="row">
           <div id="database-search-container" class="col">

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -1,10 +1,10 @@
 <!-- Search bar display -->
 <div class="pb-12">
   {%- if page.infotext and page.collection and page.collection != "posts" -%}
-    <div class="subtitle-1 pb-1" style="color: #666C7A">You are browsing</div>
+    <div class="subtitle-1 pb-1 datagov-v2-browsing">You are browsing</div>
     <div class="pb-8 subtitle-1">
       
-      {{ page.collection | replace: "-", " " | replace: "_", " " | upcase}}
+      {{ page.collection | replace: "-", " " | replace: "_", " " | capitalize}}
       {%- if page.third_nav_title -%}
         <i class="sgds-icon sgds-icon-chevron-right is-size-5 px-1" aria-hidden="true"></i>
         {{- page.third_nav_title -}}

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -1,8 +1,8 @@
 <!-- Search bar display -->
 <div class="pb-12">
   {%- if page.infotext and page.collection and page.collection != "posts" -%}
-    <div class="subtitle-1" style="color: #939393">You are browsing</div>
-    <div class="pb-8 subtitle-1 has-text-weight-semibold">
+    <div class="subtitle-1 pb-1" style="color: #666C7A">You are browsing</div>
+    <div class="pb-8 subtitle-1">
       
       {{ page.collection | replace: "-", " " | replace: "_", " " | upcase}}
       {%- if page.third_nav_title -%}
@@ -48,13 +48,13 @@
               </div>
           </div>
           <div class="is-hidden-desktop is-flex" style="flex-direction: column;">
-            <div class="col is-fullwidth is-hidden-desktop is-flex">
+            <div class="col is-fullwidth is-hidden-desktop is-flex px-0">
               <div class="is-hidden-desktop is-full-width is-full-height datagov-search-border">
                   <span class="sgds-icon sgds-icon-chevron-down is-size-4" id="filter-arrow"></span>
                   <select id="field-filter-mobile" class="sgds-selector dropdown-input">
                   </select>
               </div>
-              <div class="px-3">
+              <div class="pl-3">
                 <button type="submit" class="bp-button is-secondary is-medium has-text-white search-button">SEARCH</button>
               </div>
             </div>

--- a/_includes/datagov-search-display.html
+++ b/_includes/datagov-search-display.html
@@ -26,10 +26,7 @@
                   </span>
 
               </div>
-              <span class="px-4 is-hidden-touch is-size-5" style="align-self:center;">
-                in
-              </span>
-              <div class="col is-one-quarter p-0 mr-3 is-hidden-touch">
+              <div class="col is-one-quarter p-0 pl-4 mr-3 is-hidden-touch">
                 <div class="bp-dropdown is-full-height">
                     <a class="bp-dropdown-button hero-dropdown is-centered padding--none is-full-height" aria-haspopup="true" aria-controls="hero-dropdown-menu">
                     <div class="bp-dropdown-trigger remove-border">

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -11601,3 +11601,6 @@ h6 center {
   display: flex;
 }
 /*# sourceMappingURL=blueprint.css.map */
+.datagov-v2-browsing {
+  color: #666C7A;
+}


### PR DESCRIPTION
This PR adds informational text at the top of a dgs v2 page which informs the user which category/third nav they are searching within. As some agencies may prefer not to have this additional text, this is triggered only if a new field `infotext: true` is present in the front matter of the page.

Resolves IS-770

Tasks after merge:

- [ ] Add `infotext: true` to all e-gazette dgsv2 pages