### PR TITLE
chore: hide search icon in hamburger

### DIFF
--- a/_includes/agencyhead.html
+++ b/_includes/agencyhead.html
@@ -18,20 +18,20 @@
         </div>
         <div id="navbarExampleTransparentExample" class="bp-container is-fluid margin--none navbar-menu">
             <div class="navbar-start">
+                {%- if hide_search != true -%}
                 <div class="navbar-item is-hidden-widescreen is-search-bar">
                     <form action="/search/" method="get">
                         <div class="field has-addons">
                             <div class="control has-icons-left is-expanded">
                                 <input class="input is-fullwidth" id="search-box-mobile" type="text" placeholder="What are you looking for?" name="query">
-                                {%- if hide_search != true -%}
                                     <span class="is-large is-left">
                                     <i class="sgds-icon sgds-icon-search search-bar"></i>
                                     </span>
-                                {%- endif -%}
                             </div>
                         </div>
                     </form>
                 </div>
+                {%- endif -%}
                 {%- comment -%}
                     Left nav pages (level 2) will all belong to their own collection
                     navigation.yml will simply specify the order of level 1 and level 2 pages (1 level in navigation.yml only)

--- a/_includes/agencyhead.html
+++ b/_includes/agencyhead.html
@@ -23,10 +23,11 @@
                         <div class="field has-addons">
                             <div class="control has-icons-left is-expanded">
                                 <input class="input is-fullwidth" id="search-box-mobile" type="text" placeholder="What are you looking for?" name="query">
-                                <span class="is-large is-left">
-                                  <i class="sgds-icon sgds-icon-search search-bar"></i>
-                                </span>
-
+                                {%- if hide_search != true -%}
+                                    <span class="is-large is-left">
+                                    <i class="sgds-icon sgds-icon-search search-bar"></i>
+                                    </span>
+                                {%- endif -%}
                             </div>
                         </div>
                     </form>

--- a/assets/js/algolia-search.js
+++ b/assets/js/algolia-search.js
@@ -17,6 +17,7 @@ search.addWidgets([
   }),
   instantsearch.widgets.poweredBy({
     container: "#poweredby",
+    theme: 'dark',
   }),
   instantsearch.widgets.hits({
     container: "#hits",


### PR DESCRIPTION
Only applies to certain sites which have disabled the general search (currently just egaz)
Before:
<img width="1069" alt="Screenshot 2023-11-21 at 1 34 26 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/fb22940a-3829-4280-ace1-b08eae5a7242">



After:

<img width="1070" alt="Screenshot 2023-11-21 at 1 33 14 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/54bcc4bb-e8cf-4687-9600-10978ded5538">
