### PR TITLE
feat(cards): add css styling for page cards block

### DIFF
--- a/_sass/components/_cards.scss
+++ b/_sass/components/_cards.scss
@@ -10,6 +10,11 @@
     margin-top: 1.5rem;
   }
 
+  // Add bottom margin unless the card grid is the last item on the page
+  &:not(:has(+ #related-content)) {
+    margin-bottom: 1.5rem;
+  }
+
   .isomer-card {
     float: left;
     flex-basis: calc((100% - 3rem) / 3);

--- a/_sass/components/_cards.scss
+++ b/_sass/components/_cards.scss
@@ -13,6 +13,7 @@
     border-width: 1px;
     border-style: solid;
     border-color: #d2d2d2;
+    position: relative;
 
     // Stretch cards if there are only 2 cards
     &:nth-child(1):nth-last-child(2),
@@ -81,6 +82,16 @@
       .isomer-card-description:has(+ .isomer-card-link) {
         margin-bottom: 1.5rem;
       }
+    }
+
+    .isomer-card-cardlink {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      text-decoration: none;
+      z-index: 1;
     }
   }
 }

--- a/_sass/components/_cards.scss
+++ b/_sass/components/_cards.scss
@@ -1,0 +1,86 @@
+@use "sass:map";
+
+.isomer-card-grid {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+
+  .isomer-card {
+    float: left;
+    flex-basis: calc((100% - 3rem) / 3);
+    flex-shrink: 0;
+    border-width: 1px;
+    border-style: solid;
+    border-color: #d2d2d2;
+
+    // Stretch cards if there are only 2 cards
+    &:nth-child(1):nth-last-child(2),
+    &:nth-child(2):nth-last-child(1) {
+      flex-basis: calc((100% - 1.5rem) / 2);
+    }
+
+    // Stretch the card if there is only 1 card
+    &:only-child {
+      flex-basis: 100%;
+    }
+
+    // Collapse to 2 columns between md and xl
+    @media screen and (max-width: map-get($breakpoints, "xl")) {
+      flex-basis: calc((100% - 1.5rem) / 2);
+    }
+
+    // Collapse to 1 column below md
+    @media screen and (max-width: map-get($breakpoints, "md")) {
+      flex-basis: 100%;
+
+      &:nth-child(1):nth-last-child(2),
+      &:nth-child(2):nth-last-child(1) {
+        flex-basis: 100%;
+      }
+    }
+
+    .isomer-card-image {
+      img {
+        width: 100%;
+        height: 12.5rem;
+        object-fit: cover;
+      }
+    }
+
+    .isomer-card-body {
+      padding: 1.5rem;
+
+      .isomer-card-title {
+        color: $secondary-color;
+        font-weight: 700;
+        font-size: 1.25rem;
+        line-height: 1.75rem;
+      }
+
+      .isomer-card-description {
+        color: $content-base;
+        font-size: 1rem;
+        line-height: 1.5rem;
+      }
+
+      .isomer-card-link {
+        font-size: 1rem;
+        line-height: 1.5rem;
+
+        a {
+          text-decoration: none;
+        }
+      }
+
+      .isomer-card-title:has(+ .isomer-card-description) {
+        margin-bottom: 0.75rem;
+      }
+
+      .isomer-card-title:has(+ .isomer-card-link),
+      .isomer-card-description:has(+ .isomer-card-link) {
+        margin-bottom: 1.5rem;
+      }
+    }
+  }
+}

--- a/_sass/components/_cards.scss
+++ b/_sass/components/_cards.scss
@@ -6,14 +6,27 @@
   flex-wrap: wrap;
   gap: 1.5rem;
 
+  &:not(:first-child) {
+    margin-top: 1.5rem;
+  }
+
   .isomer-card {
     float: left;
     flex-basis: calc((100% - 3rem) / 3);
     flex-shrink: 0;
     border-width: 1px;
     border-style: solid;
-    border-color: #d2d2d2;
-    position: relative;
+    border-color: $border-light;
+    text-decoration: none;
+    margin-bottom: 0;
+
+    &:hover {
+      text-decoration: none;
+
+      .isomer-card-body .isomer-card-link {
+        color: $interaction-link-hover;
+      }
+    }
 
     // Stretch cards if there are only 2 cards
     &:nth-child(1):nth-last-child(2),
@@ -60,7 +73,7 @@
       }
 
       .isomer-card-description {
-        color: $content-base;
+        color: $content-body;
         font-size: 1rem;
         line-height: 1.5rem;
       }
@@ -68,10 +81,8 @@
       .isomer-card-link {
         font-size: 1rem;
         line-height: 1.5rem;
-
-        a {
-          text-decoration: none;
-        }
+        text-decoration: underline;
+        color: $interaction-link-default;
       }
 
       .isomer-card-title:has(+ .isomer-card-description) {
@@ -82,16 +93,6 @@
       .isomer-card-description:has(+ .isomer-card-link) {
         margin-bottom: 1.5rem;
       }
-    }
-
-    .isomer-card-cardlink {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      text-decoration: none;
-      z-index: 1;
     }
   }
 }

--- a/_sass/components/_index.scss
+++ b/_sass/components/_index.scss
@@ -1,1 +1,2 @@
 @import "./homepage";
+@import "./cards";

--- a/_sass/theme/_colors.scss
+++ b/_sass/theme/_colors.scss
@@ -1,10 +1,18 @@
 $canvas-base: #ffffff;
-$content-base: #344054;
-$utility-theme-color: $primary-color;
 $canvas-inverse: #000000;
-$content-inverse: #ffffff;
-$utility-secondary-color: $secondary-color;
 $canvas-translucent-grey: #00000080;
+
+$content-base: #344054;
+$content-body: #484848;
+$content-inverse: #ffffff;
+
+$utility-theme-color: $primary-color;
+$utility-secondary-color: $secondary-color;
+
 $interaction-hover: #f9f9f9;
+$interaction-link-default: #4372d6;
+$interaction-link-hover: #3a79ff;
+
 $stroke-default: #d0d5dd;
+
 $border-light: #d6d6d6;


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Part of 618.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Card blocks on normal pages are now supported.

## Before & After Screenshots

<img width="893" alt="Screenshot 2023-11-22 at 14 34 34" src="https://github.com/isomerpages/isomerpages-template/assets/27919917/54999416-963c-4478-930e-766c8b7b5f50">
<img width="889" alt="Screenshot 2023-11-22 at 14 34 53" src="https://github.com/isomerpages/isomerpages-template/assets/27919917/b45a8ad2-54da-468c-9e3f-d9047f8b8311">
<img width="873" alt="Screenshot 2023-11-22 at 14 35 02" src="https://github.com/isomerpages/isomerpages-template/assets/27919917/de2027d8-899b-4ff3-92e6-63a7e557065d">
<img width="873" alt="Screenshot 2023-11-22 at 14 35 11" src="https://github.com/isomerpages/isomerpages-template/assets/27919917/183f6d30-78e5-4a57-bb1d-5d95a58b9e07">

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to [this test site](https://staging.d2jyc2gar8zmvz.amplifyapp.com/cards/) and also [this page](https://staging.d2jyc2gar8zmvz.amplifyapp.com/third-nav/cards/)
    - [ ] Verify that the cards design matches that of Figma for desktop, tablet and mobile viewports

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*