### PR TITLE
chore/swap fonts

### DIFF
--- a/_sass/theme/_text-styles.scss
+++ b/_sass/theme/_text-styles.scss
@@ -3,7 +3,6 @@
 .display-1 {
   color: $content-base;
 
-  font-family: Lato;
   font-size: 4rem;
   font-style: normal;
   font-weight: 700;
@@ -16,7 +15,6 @@
   .h1 {
     color: $content-base;
 
-    font-family: Lato;
     font-size: 3rem;
     font-style: normal;
     font-weight: 700;
@@ -30,7 +28,6 @@
   .h1 {
     color: $content-base;
 
-    font-family: Lato;
     font-size: 2.75rem;
     font-style: normal;
     font-weight: 700;
@@ -42,7 +39,6 @@
 .h2 {
   color: $content-base;
 
-  font-family: Lato;
   font-size: 2rem;
   font-style: normal;
   font-weight: 700;
@@ -54,7 +50,6 @@
   color: $content-base;
 
   font-feature-settings: "clig" off, "liga" off;
-  font-family: Lato;
   font-size: 1.625rem;
   font-style: normal;
   font-weight: 700;
@@ -65,7 +60,6 @@
   color: $content-base;
 
   /* new-subtitle-1 */
-  font-family: Lato;
   font-size: 1.125rem;
   font-style: normal;
   font-weight: 400;
@@ -77,7 +71,6 @@
   color: $content-base;
 
   /* new-subtitle-2 */
-  font-family: Lato;
   font-size: 1rem;
   font-style: normal;
   font-weight: 400;
@@ -92,7 +85,6 @@
   font-feature-settings: "clig" off, "liga" off;
 
   /* new-body-1 */
-  font-family: Lato;
   font-size: 1.25rem;
   font-style: normal;
   font-weight: 400;
@@ -103,7 +95,6 @@
   color: $content-base;
 
   font-feature-settings: "clig" off, "liga" off;
-  font-family: Lato;
   font-size: 1.125rem;
   font-style: normal;
   font-weight: 400;
@@ -116,7 +107,6 @@
   font-feature-settings: "clig" off, "liga" off;
 
   /* new-linkbutton */
-  font-family: Lato;
   font-size: 1.125rem;
   font-style: normal;
   font-weight: 600;
@@ -137,7 +127,6 @@
   font-feature-settings: "clig" off, "liga" off;
 
   /* new-buttontext */
-  font-family: Lato;
   font-size: 1rem;
   font-style: normal;
   font-weight: 600;
@@ -151,7 +140,6 @@
   font-feature-settings: "clig" off, "liga" off;
 
   /* new-link */
-  font-family: Lato;
   font-size: 1.125rem;
   font-style: normal;
   font-weight: 600;

--- a/assets/css/blueprint.css
+++ b/assets/css/blueprint.css
@@ -365,8 +365,7 @@ button,
 input,
 select,
 textarea {
-  font-family: "Lato", BlinkMacSystemFont, -apple-system, "Segoe UI",
-    "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  font-family: "Inter", BlinkMacSystemFont, -apple-system, "Segoe UI", "Helvetica Neue", sans-serif;
 }
 
 code,
@@ -5262,7 +5261,6 @@ a[href$=".pdf"][target="_blank"]:after {
 }
 
 .sgds-selector {
-  font-family: Lato;
   font-size: 18px;
   border: none;
   background-color: transparent;
@@ -9506,11 +9504,6 @@ li .highlight {
   color: #009999;
 }
 
-/* Literal.Number.Integer.Long */
-* {
-  font-family: "Lato", sans-serif;
-}
-
 @font-face {
   font-family: "sgds-icons";
   src: url("./fonts/sgds-icons.eot?#iefix") format("embedded-opentype"),
@@ -10337,7 +10330,6 @@ html.has-navbar-fixed-top-widescreen {
 }
 
 .display {
-  font-family: "Lato", sans-serif;
   font-size: 5.25rem;
   letter-spacing: -1.5px;
   line-height: 5.25rem;
@@ -10357,13 +10349,11 @@ html.has-navbar-fixed-top-widescreen {
 p,
 li,
 center {
-  font-family: "Lato", sans-serif;
   font-size: 1.25rem;
   line-height: 2rem;
 }
 
 small {
-  font-family: "Lato", sans-serif;
   font-size: 0.9375rem;
   letter-spacing: 0.2px;
 }
@@ -10376,7 +10366,6 @@ strong {
 
 h1,
 h1 center {
-  font-family: "Lato", sans-serif;
   font-size: 3.375rem;
   line-height: 3.75rem;
   letter-spacing: -1.5px;
@@ -10397,7 +10386,6 @@ h1 center {
 
 h2,
 h2 center {
-  font-family: "Lato", sans-serif;
   font-size: 2.75rem;
   line-height: 3.75rem;
 }
@@ -10410,7 +10398,6 @@ h2 center {
 
 h3,
 h3 center {
-  font-family: "Lato", sans-serif;
   font-size: 2rem;
   line-height: 2.8125rem;
 }
@@ -10423,7 +10410,6 @@ h3 center {
 
 h4,
 h4 center {
-  font-family: "Lato", sans-serif;
   font-size: 1.625rem;
   line-height: 1.875rem;
 }
@@ -10436,7 +10422,6 @@ h4 center {
 
 h5,
 h5 center {
-  font-family: "Lato", sans-serif;
   font-size: 1.375rem;
   line-height: 1.875rem;
 }
@@ -10449,7 +10434,6 @@ h5 center {
 
 h6,
 h6 center {
-  font-family: "Lato", sans-serif;
   font-size: 1rem;
   line-height: 1.25rem;
 }
@@ -11115,7 +11099,6 @@ h6 center {
 }
 
 * {
-  font-family: "Lato", sans-serif;
 }
 
 .is-vh-10 {


### PR DESCRIPTION
Note: This should not be merged in immediately - we want to roll this out incrementally, through a separate branch for a couple of sites initially.

This PR swaps out the existing font styles. Existing specifications of font styles have been removed where unnecessary, as the font styles are specified for the entire body.

old fonts:
<img width="1429" alt="Screenshot 2023-11-29 at 2 13 58 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/6e2a281f-d6da-4234-9343-82c3014c8418">
new fonts:
<img width="1461" alt="Screenshot 2023-11-29 at 2 14 30 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/4dc33e02-dcd9-4d88-9f77-f72253840073">


example site:
https://staging.duyfy15grdtiq.amplifyapp.com/