### PR TITLE
fix: prevent staging sites from being indexed by robots

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -32,6 +32,10 @@
         {{- site.data.navigation.logo | absolute_url -}}
     {%- endif -%}">
     <meta property="og:url" content="{{- page.url | absolute_url -}}">
+    {%- comment -%} Prevent our staging sites from appearing in Google search results {%- endcomment -%}
+    {%- if jekyll.environment == "staging" -%}
+        <meta name="robots" content="noindex">
+    {%- endif -%}
     <link rel="canonical" href="{{- page.url | absolute_url -}}" />
 
     {%- if site.favicon -%}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Our staging sites are being indexed by Google, which is not desirable.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Add a `noindex` rule to prevent robots from indexing the site, if the Jekyll environment is defined to be staging (i.e. it is a staging site).
    - The instructions to block indexing is available in this support article: https://developers.google.com/search/docs/crawling-indexing/block-indexing
    - The logic to differentiate between environments is reused from the masthead.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Build a site using this branch
    - [ ] Verify that the meta tag is added to the page (minimally the homepage but this should apply to every page)
    - [ ] Build another production site using this branch
    - [ ] Verify that the meta tag is not added to the page

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*