### PR TITLE
fix(cards): prevent overflowing of cards by enforcing width

### DIFF
--- a/_sass/components/_cards.scss
+++ b/_sass/components/_cards.scss
@@ -18,6 +18,7 @@
   .isomer-card {
     float: left;
     flex-basis: calc((100% - 3rem) / 3);
+    max-width: calc((100% - 3rem) / 3);
     flex-shrink: 0;
     border-width: 1px;
     border-style: solid;
@@ -37,25 +38,30 @@
     &:nth-child(1):nth-last-child(2),
     &:nth-child(2):nth-last-child(1) {
       flex-basis: calc((100% - 1.5rem) / 2);
+      max-width: calc((100% - 1.5rem) / 2);
     }
 
     // Stretch the card if there is only 1 card
     &:only-child {
       flex-basis: 100%;
+      max-width: 100%;
     }
 
     // Collapse to 2 columns between md and xl
     @media screen and (max-width: map-get($breakpoints, "xl")) {
       flex-basis: calc((100% - 1.5rem) / 2);
+      max-width: calc((100% - 1.5rem) / 2);
     }
 
     // Collapse to 1 column below md
     @media screen and (max-width: map-get($breakpoints, "md")) {
       flex-basis: 100%;
+      max-width: 100%;
 
       &:nth-child(1):nth-last-child(2),
       &:nth-child(2):nth-last-child(1) {
         flex-basis: 100%;
+        max-width: 100%;
       }
     }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The cards grid block does not handle overflow nicely, which causes the cards to look quite jank when overflowing happens. [Here's an example](https://www.peichunpublic.moe.edu.sg/useful-info/technology-learning-platform/).

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Set a `max-width` attribute so that we can enforce the width of the cards. This approach was guided [by this answer](https://stackoverflow.com/a/54005082).

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="1056" alt="Screenshot 2024-01-10 at 13 48 56" src="https://github.com/isomerpages/isomerpages-template/assets/27919917/f81284d1-332a-4957-b5ea-c815025ac117">


**AFTER**:

<!-- [insert screenshot here] -->
<img width="1219" alt="Screenshot 2024-01-10 at 13 49 06" src="https://github.com/isomerpages/isomerpages-template/assets/27919917/64250ce0-afe5-4df0-9592-86fc80cff3f9">


## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Create a page with the Isomer card grid block and add text that will definitely cause a text overflow (such as a long URL). You can use [this test page](https://test-aws.test-isomer.gov.sg/new/cards/) (to compare against [the original version](https://www.peichunpublic.moe.edu.sg/useful-info/technology-learning-platform/)).
    - [ ] Verify that the card grid is maintained for all viewports.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*