### PR TITLE
feat: use human readable title instead of field title

### DIFF
--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -78,7 +78,8 @@ function databaseSearch(searchTerm, index, callback) {
   //   title: represents human readable field
   let request, columnMetadata
   let formattedSearchField = searchField ? searchField.replace(" ", "_") : ""
-  if (!!defaultField) {
+  const isDgsV2 = !!defaultField // Only dgs-v2 has default field
+  if (isDgsV2) {
     // Datagov-v2 search - query for dataset metadata first to retrieve column info
     request = $.ajax({
       url: `https://api-production.data.gov.sg/v2/public/api/datasets/${resourceId}/metadata`,

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -89,12 +89,10 @@ function databaseSearch(searchTerm, index, callback) {
         id: item.name,
         title: item.columnTitle
       }))
-      if (formattedSearchField) {
+      if (formattedSearchField && searchTerm !== "") {
         const filteredSearchColumn = columnMetadata.filter((col) => col.title.toLowerCase() === formattedSearchField.toLowerCase())
         formattedSearchField = filteredSearchColumn[0].id
         data.q = JSON.stringify({[formattedSearchField]: searchTerm})
-      } else {
-        data.q = searchTerm
       }
       return $.ajax({
         url: 'https://data.gov.sg/api/action/datastore_search',

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -124,7 +124,6 @@ function databaseSearch(searchTerm, index, callback) {
         title: field.id,
       }))
     }
-    columnMetadata = columnMetadata || data.result.fields
     if (isFirstRender) {
       pageResults = Array(Math.ceil(datagovsgTotal / PAGINATION_DISPLAY_RESULTS_PER_PAGE)).fill(null);
     } else {

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -73,18 +73,29 @@ function databaseSearch(searchTerm, index, callback) {
     offset
   };
 
-  let request
+  // columnMetadata:
+  //   id: represents searchable field
+  //   title: represents human readable field
+  let request, columnMetadata
   let formattedSearchField = searchField ? searchField.replace(" ", "_") : ""
-  if (!!searchField) {
-    // Datagov-v2 search
+  if (!!defaultField) {
+    // Datagov-v2 search - query for dataset metadata first to retrieve column info
     request = $.ajax({
       url: `https://api-production.data.gov.sg/v2/public/api/datasets/${resourceId}/metadata`,
       dataType: 'json'
     }).then((resp) => {
-      const columnNames = Object.values(resp.data.columnMetadata.map)
-      const filteredSearchColumn = columnNames.filter((colName) => colName.toLowerCase() === formattedSearchField.toLowerCase())
-      formattedSearchField = filteredSearchColumn[0]
-      data.q = JSON.stringify({[formattedSearchField]: searchTerm})
+      const respData = Object.values(resp.data.columnMetadata.metaMapping)
+      columnMetadata = respData.map(item => ({
+        id: item.name,
+        title: item.columnTitle
+      }))
+      if (formattedSearchField) {
+        const filteredSearchColumn = columnMetadata.filter((col) => col.title.toLowerCase() === formattedSearchField.toLowerCase())
+        formattedSearchField = filteredSearchColumn[0].id
+        data.q = JSON.stringify({[formattedSearchField]: searchTerm})
+      } else {
+        data.q = searchTerm
+      }
       return $.ajax({
         url: 'https://data.gov.sg/api/action/datastore_search',
         data: data,
@@ -106,6 +117,14 @@ function databaseSearch(searchTerm, index, callback) {
 
   request.done(function (data) {
     datagovsgTotal = data.result.total;
+    if (!columnMetadata) {
+      // V1 search, id and title are the same
+      columnMetadata = data.result.fields.map(field => ({
+        id: field.id,
+        title: field.id,
+      }))
+    }
+    columnMetadata = columnMetadata || data.result.fields
     if (isFirstRender) {
       pageResults = Array(Math.ceil(datagovsgTotal / PAGINATION_DISPLAY_RESULTS_PER_PAGE)).fill(null);
     } else {
@@ -115,12 +134,12 @@ function databaseSearch(searchTerm, index, callback) {
 
     // The fieldArray is the array containing the field names in the data.gov.sg table
     const removableFields = ["_id", "_full_count", "rank", `rank ${formattedSearchField}`]
-    fieldArray = remove(data.result.fields, removableFields);
+    fieldArray = remove(columnMetadata, removableFields);
     const pageResultArray = splitPages(data.result.records, PAGINATION_DISPLAY_RESULTS_PER_PAGE)
     const startingPage = offset / PAGINATION_DISPLAY_RESULTS_PER_PAGE
     const possibleSearchField = formattedSearchField || defaultField
     if (!hasPopulatedFields && possibleSearchField) {
-      displaySearchFilterDropdown(fieldArray.map(item => item.id), possibleSearchField);
+      displaySearchFilterDropdown(fieldArray, possibleSearchField);
       hasPopulatedFields = true
     }
     pageResultArray.forEach((pageData, idx) => {
@@ -158,7 +177,7 @@ function displayTable(chunk, fields) {
 
   var resultString = "<div><table class=\"table-h\"><tr>";
   for (var fieldIndex in fields) {
-    var fieldId = fields[fieldIndex].id;
+    var fieldId = fields[fieldIndex].title;
     resultString += '<td><h6 class=\"margin--none\"><b>' + fieldId.replace(/_/g, ' ').toUpperCase() + '</b></h6></td>';
   }
   resultString += '</tr>';
@@ -197,8 +216,8 @@ function displaySearchFilterDropdown(fields, startingField) {
   var fieldFilterDesktop = document.getElementById('field-filter-desktop');
   var fieldFilterMobile = document.getElementById('field-filter-mobile');
 
-  for (let raw_field of fields) {
-    const field = deslugify(raw_field)
+  for (let fieldMetadata of fields) {
+    const field = deslugify(fieldMetadata.title)
     const deslugifiedStartingField = deslugify(startingField)
     // Creating the select element for mobile view
     var option = document.createElement("option");

--- a/assets/js/datagovsg-search.js
+++ b/assets/js/datagovsg-search.js
@@ -118,6 +118,7 @@ function databaseSearch(searchTerm, index, callback) {
     datagovsgTotal = data.result.total;
     if (!columnMetadata) {
       // V1 search, id and title are the same
+      // We already have the data from the earlier request because we wait for request.done
       columnMetadata = data.result.fields.map(field => ({
         id: field.id,
         title: field.id,


### PR DESCRIPTION
This PR modifies the behaviour for dgs-v2 pages. For datasets on dgs v2, fields have both an internal name (e.g. `notification_no`) and a human readable name (e.g. `Notification number`). We previously were using the internal name for the display of the table header, as well as the field dropdown, as the dgs-v1 datasets only contain an internal name. This PR changes that behaviour such that dgs-v2 pages will use the new human readable names for page display, while still sending the internal name to be used for search queries.

Note that this means the field provided by the frontmatter should now be the human readable name. However, existing pages are unaffected in functionality - for the 2 sites currently making use of dgs-v2 pages, the deslugified versions of the internal representation and the field name are identical.