### PR TITLE
Fix/import lunr

### DIFF
--- a/_includes/main_scripts.html
+++ b/_includes/main_scripts.html
@@ -64,7 +64,7 @@
 {%- endif -%}
 
 {%- if page.layout == 'page' or page.layout == 'our-team' or page.layout == 'our-journey' or page.layout == 'post' -%}
-<script src="https://printjs-4de6.kxcdn.com/print.min.js" integrity="sha384-7KBAAc532qVa9KK+IJzrJFWPLznPFKPl0vCBPrL1oOE7UKArUYXICoXh0qKdGBda" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/print-js/1.6.0/print.min.js" integrity="sha512-16cHhHqb1CbkfAWbdF/jgyb/FDZ3SdQacXG8vaOauQrHhpklfptATwMFAc35Cd62CQVN40KDTYo9TIsQhDtMFg==" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/floating-buttons.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="{{- "/assets/js/left-nav-interaction.js" | relative_url -}}" crossorigin="anonymous"></script>
 <script src="https://www.instagram.com/static/bundles/es6/EmbedSDK.js/ab12745d93c5.js" integrity="sha384-uCmurhfuSbKidtlFxpgv2j4yIWVfYbrJaFrj62TR3NpFp+msiMilcvgz0gsDY2Yj" crossorigin="anonymous"></script>

--- a/assets/js/worker.js
+++ b/assets/js/worker.js
@@ -1,16 +1,27 @@
-onmessage = async function(event) {
-	if( 'function' !== typeof importScripts) return
-	const scriptUrl = 'https://unpkg.com/lunr/lunr.js';
-  const integrityHash = 'sha256-lDFybwXA6uKm5U3Bl3CUIoafJcrUTyQw0vt92ugMxxc=';
 
+let loaded = false;
+
+async function loadcontext() {
+	if (loaded) return;
+
+	if( 'function' !== typeof importScripts) return
+	const scriptUrl = 'https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.9/lunr.min.js';
+	const integrityHash = 'sha512-4xUl/d6D6THrAnXAwGajXkoWaeMNwEKK4iNfq5DotEbLPAfk6FSxSP3ydNxqDgCw1c/0Z1Jg6L8h2j+++9BZmg=='; // retrieved from cdnjs
+
+	await fetch(scriptUrl, { integrity: integrityHash });
+	// We use fetch only to verify integrity - we still use importScripts to avoid inline script
+	importScripts(scriptUrl);
+
+	loaded = true;
+}
+
+onmessage = async function(event) {
 	try {
-		await fetch(scriptUrl, { integrity: integrityHash });
+		await loadcontext();
 	} catch (err) {
 		console.log(err)
 		return
 	}
-	// We use fetch only to verify integrity - we still use importScripts to avoid inline script
-	importScripts(scriptUrl);
 
 	var documents = event.data;
 

--- a/assets/js/worker.js
+++ b/assets/js/worker.js
@@ -3,8 +3,7 @@ let loaded = false;
 
 async function loadcontext() {
 	if (loaded) return;
-
-	if( 'function' !== typeof importScripts) return
+	if( 'function' !== typeof importScripts) throw new Error("Unable to load context")
 	const scriptUrl = 'https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.9/lunr.min.js';
 	const integrityHash = 'sha512-4xUl/d6D6THrAnXAwGajXkoWaeMNwEKK4iNfq5DotEbLPAfk6FSxSP3ydNxqDgCw1c/0Z1Jg6L8h2j+++9BZmg=='; // retrieved from cdnjs
 

--- a/assets/js/worker.js
+++ b/assets/js/worker.js
@@ -1,6 +1,7 @@
 let scriptLoaded = false;
 
 onmessage = async function(event) {
+	if( 'function' !== typeof importScripts) return
 	const scriptUrl = 'https://unpkg.com/lunr/lunr.js';
   const integrityHash = 'sha256-lDFybwXA6uKm5U3Bl3CUIoafJcrUTyQw0vt92ugMxxc=';
 	if (scriptLoaded) return

--- a/assets/js/worker.js
+++ b/assets/js/worker.js
@@ -9,6 +9,7 @@ onmessage = async function(event) {
 		console.log(err)
 		return
 	}
+	// We use fetch only to verify integrity - we still use importScripts to avoid inline script
 	importScripts(scriptUrl);
 
 	var documents = event.data;

--- a/assets/js/worker.js
+++ b/assets/js/worker.js
@@ -1,27 +1,16 @@
-let scriptLoaded = false;
-
 onmessage = async function(event) {
 	if( 'function' !== typeof importScripts) return
 	const scriptUrl = 'https://unpkg.com/lunr/lunr.js';
   const integrityHash = 'sha256-lDFybwXA6uKm5U3Bl3CUIoafJcrUTyQw0vt92ugMxxc=';
-	if (scriptLoaded) return
 
-	let response
-	if (!scriptLoaded) {
-		try {
-			response = await fetch(scriptUrl, { integrity: integrityHash });
-		} catch (err) {
-			console.log(err)
-			return
-		}
+	try {
+		await fetch(scriptUrl, { integrity: integrityHash });
+	} catch (err) {
+		console.log(err)
+		return
 	}
-	const scriptText = await response.text();
+	importScripts(scriptUrl);
 
-	// Create a script element and append the loaded script
-	const scriptElement = new Function(scriptText);
-	scriptElement();
-
-	scriptLoaded = true
 	var documents = event.data;
 
 	var index = lunr(function () {


### PR DESCRIPTION
This PR fixes issues introduced by https://github.com/isomerpages/isomerpages-template/pull/380. Our CSP disallows inline scripts, so creating the script element using `new Function` would cause issues. This CSP reverts to using `importScripts`, but only after the integrity has been verified via `fetch`. It also fixes a bug where the worker script was being called on every pass instead of just through the worker context.

~To be reviewed in conjunction with https://github.com/opengovsg/isomer-build/pull/62 and https://github.com/opengovsg/isomer-build/pull/63, as `fetch` requires new `connect-src` rules.~ No longer necessary - we now use a different script src which is already whitelisted

Can be tested on https://staging.duyfy15grdtiq.amplifyapp.com/search/?query=lorem