### PR TITLE
feat: add text search to algolia

### DIFF
--- a/assets/js/algolia-search.js
+++ b/assets/js/algolia-search.js
@@ -57,6 +57,16 @@ search.addWidgets([
             <p class="search-content description ml-9">Publish date: ${new Date(
               hit.publishTimestamp
             ).toLocaleDateString("fr-CA")}</p>
+            ${hit.text 
+              ? `<p class="search-content description ml-9">Content: ${instantsearch.snippet(
+                {
+                  attribute: "text",
+                  highlightedTagName: "mark",
+                  hit,
+                }
+              )}</p>`
+              : ""
+            }
             <p>
              </h5>
           `;


### PR DESCRIPTION
Adds a field for hits to allow users to search by text content for algolia search.

After: adds snippet `Content` if it exists in the record
<img width="1548" alt="Screenshot 2024-03-18 at 1 14 23 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/86502f93-6eb1-4e20-84ec-b06e347324a7">
