### PR TITLE
fix: add wrap style for hero button to other formats

### DIFF
--- a/_includes/homepage/hero/components/hero-infobox-desktop.html
+++ b/_includes/homepage/hero/components/hero-infobox-desktop.html
@@ -30,7 +30,7 @@
       <div>
         <a
           href="{{- site.baseurl -}}{{- section.hero.url -}}"
-          class="bp-button is-secondary is-uppercase search-button"
+          class="bp-button is-secondary is-uppercase search-button hero-button"
         >
           {{- section.hero.button -}}
         </a>

--- a/_includes/homepage/hero/components/hero-infobox-mobile.html
+++ b/_includes/homepage/hero/components/hero-infobox-mobile.html
@@ -27,7 +27,7 @@
     section.hero.button -%}
     <a
       href="{{- site.baseurl -}}{{- section.hero.url -}}"
-      class="bp-button is-secondary is-uppercase search-button"
+      class="bp-button is-secondary is-uppercase search-button hero-button"
     >
       {{- section.hero.button -}}
     </a>

--- a/_includes/homepage/hero/hero-floating-layout.html
+++ b/_includes/homepage/hero/hero-floating-layout.html
@@ -27,7 +27,7 @@
             section.hero.url and section.hero.button -%}
             <a
               href="{{- site.baseurl -}}{{- section.hero.url -}}"
-              class="bp-button is-secondary is-uppercase search-button"
+              class="bp-button is-secondary is-uppercase search-button hero-button"
             >
               {{- section.hero.button -}}
             </a>


### PR DESCRIPTION
Extension of https://github.com/isomerpages/isomerpages-template/pull/381 - this PR fixes hero button on other hero layout types.

Note that for local dev, our floating/side layouts specify the class of the parent using `{{- section.hero.size | default: 'md' -}}` - this actually never hits the default value (`md`) as `section.hero.size` returns the size of the `hero` object instead even if the `size` param is not defined. I'm opting to leave it as is because users going through the CMS flow have this field auto populated

Side layout:
<img width="1127" alt="Screenshot 2024-03-21 at 10 05 25 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/d8336997-9e0f-4bd1-abe0-dee190f33c0b">

Floating layout:
<img width="1147" alt="Screenshot 2024-03-21 at 10 06 25 PM" src="https://github.com/isomerpages/isomerpages-template/assets/22111124/8327e25d-f27b-4432-9d3e-c9914c28da0b">
