### PR TITLE
fix/report vuln link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -195,7 +195,7 @@
                             <p><a {{anchor}} title="Link to reach.gov.sg">REACH</a></p>
                         </li>
                     {%- endif -%}
-                    <li><p><a href="https://www.tech.gov.sg/report_vulnerability/">Report Vulnerability</a></p></li>
+                    <li><p><a href="https://www.tech.gov.sg/report-vulnerability/">Report Vulnerability</a></p></li>
                     {%- if site.data.footer.privacy_policy and site.data.footer.privacy_policy != "" -%}
                         {%- assign url_input = site.data.footer.privacy_policy -%}
                         {%- include functions/external_url.html -%}


### PR DESCRIPTION
tech.gov has changed their report vuln link from `https://www.tech.gov.sg/report_vulnerability` to `https://www.tech.gov.sg/report-vulnerability`

Not a breaking change since this is being handled by amplify redirect currently