### PR TITLE
chore: update gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.22.3)
     mutex_m (0.2.0)
-    nokogiri (1.15.6)
+    nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.25.1)


### PR DESCRIPTION
## Problem
`nokogiri` got vulnerability via `github-pages`. to fix, the gem has been updated

## Solution
bump `nokogiri` to 1.16.5