### PR TITLE
fix: reset pagination when changing year filter

### DIFF
--- a/assets/js/paginate-resources.js
+++ b/assets/js/paginate-resources.js
@@ -40,6 +40,9 @@ function applyFilter(selectedYear) {
   filteredArray = extractPostsByYear(selectedYear);
 
   pageResults = splitPages(filteredArray, PAGE_SIZE);
+
+  // Reset the current page index to 0
+  currentPageIndex = 0;
   unhideChunk(currentPageIndex, currentPageIndex);
 
   var filterDropdownDesktop = document.getElementById('sgds-selector-text-desktop');

--- a/assets/js/paginate-resources.js
+++ b/assets/js/paginate-resources.js
@@ -23,7 +23,6 @@ document.getElementById('year-filter-mobile').addEventListener('change', functio
 // Main function to paginate resource page
 function paginateResources() {
   resourceCardArray = Array.prototype.slice.call(document.getElementsByClassName("resource-card-element")); // Convert NodeList into Array
-  console.log(resourceCardArray);
   // 1. Display the years that are available
   var earliestYear = findEarliestYear();
   var currYear = new Date().getFullYear();


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

A user reported an issue where the pagination was not reset when selecting a year filter (refer to before and after videos).

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Ensure that the pagination is reset to the first page when applying a filter.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

https://github.com/user-attachments/assets/08274d79-6855-4aba-b71b-8c52423242ca

**AFTER**:

<!-- [insert screenshot here] -->

https://github.com/user-attachments/assets/c3931a9d-da5d-43d9-87c1-07e5612fc813

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Unit tests (using `npm run tests`)
- [ ] e2e tests (comment on this PR with the text `!run e2e`)
- [x] Smoke tests
    - [ ] Navigate to a resource room with enough resources that there is pagination.
    - [ ] Go to the last page.
    - [ ] Use the year filter to filter for the earliest year.
    - [ ] The resource room page should correctly filter for that selected year.